### PR TITLE
chore: Prepare package for publishing

### DIFF
--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -1,11 +1,15 @@
 name: Publish WebdriverIO TV Labs Service
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   Publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,7 +37,7 @@ jobs:
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --dry-run
+        run: npm publish --access public --provenance
 
       - name: Publish notification
         uses: slackapi/slack-github-action@v1.26.0


### PR DESCRIPTION
- Add provenance for organizations to audit the source and build process. See https://docs.npmjs.com/generating-provenance-statements for information.
- Add public access, required for first publish
- Trigger on published GitHub release