### PR TITLE
fix: add missing disconnect calls

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -43,6 +43,14 @@ export class TVLabsChannel {
     this.lobbyTopic = this.socket.channel('requests:lobby');
   }
 
+  disconnect(): Promise<void> {
+    return new Promise((res, _rej) => {
+      this.lobbyTopic.leave();
+      this.requestTopic?.leave();
+      this.socket.disconnect(() => res());
+    });
+  }
+
   async connect(): Promise<void> {
     log.debug('Connecting to TV Labs...');
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -40,6 +40,8 @@ export default class TVLabsService implements Services.ServiceInstance {
       capabilities,
       this.retries(),
     );
+
+    await channel.disconnect();
   }
 
   private endpoint(): string {


### PR DESCRIPTION
- Fixes issue where node scripts will pause forever (until disconnect occurs and retries are exhausted) when using this outside the WDIO test runner as shown in README.