### PR TITLE
chore: add `RELEASE_LINK` to slack publish notification

### DIFF
--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -46,6 +46,7 @@ jobs:
             {
               "VERSION": "${{ steps.package-version.outputs.version }}",
               "PACKAGE_LINK": "https://www.npmjs.com/package/@tvlabs/wdio-service/v/${{ steps.package-version.outputs.version }}",
+              "RELEASE_LINK": "https://github.com/tv-labs/wdio-tvlabs-service/releases/tag/v${{ steps.package-version.outputs.version }}",
               "PACKAGE_NAME": "@tvlabs/wdio-service"
             }
         env:


### PR DESCRIPTION
- Adds a link to the release in the slack notification payload