### PR TITLE
fix: add named export and remove chalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ yarn add @tvlabs/wdio-service
 To use this as a WebdriverIO test runner service, include the service in your WebdriverIO configuration file (e.g. `wdio.conf.ts`) with your TV Labs API key set in the options.
 
 ```javascript
-import TVLabsService from '@tvlabs/wdio-service';
+import { TVLabsService } from '@tvlabs/wdio-service';
 
 export const config = {
   // ...
@@ -54,7 +54,7 @@ To use this with WebdriverIO remote but without the test runner, call the before
 
 ```javascript
 import { remote } from 'webdriverio';
-import TVLabsService from '@tvlabs/wdio-service';
+import { TVLabsService } from '@tvlabs/wdio-service';
 
 const capabilities = { ... };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^5.1.2",
         "phoenix": "^1.7.20",
         "ws": "^8.18.3"
       },
@@ -2462,6 +2461,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
       "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvlabs/wdio-service",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "WebdriverIO service that provides a better integration into TV Labs",
   "author": "Regan Karlewicz <regan@tvlabs.ai>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "webdriverio": "^9.12.1"
   },
   "dependencies": {
-    "chalk": "^5.1.2",
     "phoenix": "^1.7.20",
     "ws": "^8.18.3"
   }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -40,7 +40,9 @@ export class TVLabsChannel {
       reconnectAfterMs: this.reconnectAfterMs.bind(this),
     });
 
-    this.socket.onError(this.logSocketError);
+    this.socket.onError((...args) =>
+      TVLabsChannel.logSocketError(...args, this.log),
+    );
 
     this.lobbyTopic = this.socket.channel('requests:lobby');
   }
@@ -248,18 +250,18 @@ export class TVLabsChannel {
     return wait;
   }
 
-  private logSocketError(
+  private tvlabsSessionLink(sessionId: string) {
+    return `https://tvlabs.ai/app/sessions/${sessionId}`;
+  }
+
+  private static logSocketError(
     event: ErrorEvent,
     _transport: new (endpoint: string) => object,
     _establishedConnections: number,
+    log: Logger,
   ) {
     const error = event.error;
-    const code = error && error.code;
 
-    this.log.error('Socket error:', code || error || event);
-  }
-
-  private tvlabsSessionLink(sessionId: string) {
-    return `https://tvlabs.ai/app/sessions/${sessionId}`;
+    log.error('Socket error:', error || event);
   }
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -41,7 +41,7 @@ export class TVLabsChannel {
     });
 
     this.socket.onError((...args) =>
-      TVLabsChannel.logSocketError(...args, this.log),
+      TVLabsChannel.logSocketError(this.log, ...args),
     );
 
     this.lobbyTopic = this.socket.channel('requests:lobby');
@@ -255,10 +255,10 @@ export class TVLabsChannel {
   }
 
   private static logSocketError(
+    log: Logger,
     event: ErrorEvent,
     _transport: new (endpoint: string) => object,
     _establishedConnections: number,
-    log: Logger,
   ) {
     const error = event.error;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import TVLabsService from './service.js';
 
+export { TVLabsService };
 export default TVLabsService;
 export * from './types.js';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,17 +1,7 @@
 import type { LogLevel } from './types.js';
-import chalk from 'chalk';
 
 // TODO: Replace this with @wdio/logger
 // It is currently not compatible with CJS
-
-const LOG_LEVEL_COLORS: Record<LogLevel, typeof chalk> = {
-  error: chalk.red,
-  warn: chalk.yellow,
-  info: chalk.cyanBright,
-  debug: chalk.green,
-  trace: chalk.cyan,
-  silent: chalk.gray,
-};
 
 const LOG_LEVELS: Record<LogLevel, number> = {
   error: 0,
@@ -37,8 +27,7 @@ export class Logger {
 
   private formatMessage(level: LogLevel, ...args: unknown[]): string {
     const timestamp = new Date().toISOString();
-    const levelColor = LOG_LEVEL_COLORS[level];
-    return `${chalk.gray(timestamp)} ${levelColor(level.toUpperCase())} ${chalk.white(this.name)}: ${args
+    return `${timestamp} ${level.toUpperCase()} ${this.name}: ${args
       .map((arg) =>
         typeof arg === 'object' ? JSON.stringify(arg) : String(arg),
       )

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,5 @@
 import { SevereServiceError } from 'webdriverio';
 import * as crypto from 'crypto';
-import chalk from 'chalk';
 
 import { TVLabsChannel } from './channel.js';
 import { Logger } from './logger.js';
@@ -80,7 +79,7 @@ export default class TVLabsService implements Services.ServiceInstance {
         requestId,
       );
 
-      this.log.info(chalk.blue('ATTACHED REQUEST ID'), requestId);
+      this.log.info('ATTACHED REQUEST ID', requestId);
 
       return originalRequestOptions;
     };


### PR DESCRIPTION
- Add named export that works better with vanilla commonjs modules (eliminate need for `.default`)
- Remove ESM-only library chalk that throws a require error in commonjs
- Fix property 'error' of this.log is undefined error in channel 