### PR TITLE
feat: improve error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,22 @@ To use this with WebdriverIO remote but without the test runner, call the before
 import { remote } from 'webdriverio';
 import { TVLabsService } from '@tvlabs/wdio-service';
 
-const capabilities = { ... };
-
-const wdOpts = {
-  capabilities,
-  hostname: 'appium.tvlabs.ai',
-  port: 4723,
-  headers: {
-    Authorization: `Bearer ${process.env.TVLABS_API_TOKEN}`,
-  },
-};
-
-const serviceOpts = {
-  apiKey: process.env.TVLABS_API_TOKEN,
-}
-
 async function run() {
+  const capabilities = { ... };
+
+  const wdOpts = {
+    capabilities,
+    hostname: 'appium.tvlabs.ai',
+    port: 4723,
+    headers: {
+      Authorization: `Bearer ${process.env.TVLABS_API_TOKEN}`,
+    },
+  };
+
+  const serviceOpts = {
+    apiKey: process.env.TVLABS_API_TOKEN,
+  }
+
   const service = new TVLabsService(serviceOpts, capabilities, {})
 
   // The TV Labs service does not use specs or a cid, pass default values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tvlabs/wdio-service",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tvlabs/wdio-service",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "phoenix": "^1.7.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvlabs/wdio-service",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "WebdriverIO service that provides a better integration into TV Labs",
   "author": "Regan Karlewicz <regan@tvlabs.ai>",
   "license": "Apache-2.0",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -266,8 +266,6 @@ export class TVLabsChannel {
     _transport: new (endpoint: string) => object,
     _establishedConnections: number,
   ) {
-    const error = event.error;
-
-    log.error('Socket error:', error || event);
+    log.error('Socket error:', event.error);
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -68,7 +68,7 @@ export class Logger {
             const props: Record<string, unknown> = {};
             keys.forEach((key) => {
               try {
-                const value = (arg as any)[key];
+                const value = (arg as Record<string, unknown>)[key];
                 if (value instanceof Error) {
                   props[key] = `${value.name}: ${value.message}`;
                 } else {

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -42,7 +42,10 @@ describe('Logger', () => {
 
     it('should handle Error objects with additional properties', () => {
       const logger = new Logger('test', 'debug');
-      const customError = new Error('Custom error message') as any;
+      const customError = new Error('Custom error message') as Error & {
+        code?: string;
+        statusCode?: number;
+      };
       customError.code = 'CUSTOM_CODE';
       customError.statusCode = 500;
 

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,177 @@
+import { Logger } from '../src/logger.js';
+
+describe('Logger', () => {
+  let consoleSpy: {
+    log: ReturnType<typeof vi.spyOn>;
+    error: ReturnType<typeof vi.spyOn>;
+    warn: ReturnType<typeof vi.spyOn>;
+    trace: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    consoleSpy = {
+      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      trace: vi.spyOn(console, 'trace').mockImplementation(() => {}),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Error object serialization', () => {
+    it('should properly serialize Error objects with stack trace', () => {
+      const logger = new Logger('test', 'debug');
+      const error = new Error('Test error message');
+
+      logger.error('Socket error:', error);
+
+      const logCall = consoleSpy.error.mock.calls[0][0];
+      expect(logCall).toContain('Socket error:');
+      expect(logCall).toContain('Error: Test error message');
+      expect(logCall).toContain('at '); // Stack trace should be present
+
+      // Should not have duplicate error message
+      const errorMessageCount = (
+        logCall.match(/Error: Test error message/g) || []
+      ).length;
+      expect(errorMessageCount).toBe(1);
+    });
+
+    it('should handle Error objects with additional properties', () => {
+      const logger = new Logger('test', 'debug');
+      const customError = new Error('Custom error message') as any;
+      customError.code = 'CUSTOM_CODE';
+      customError.statusCode = 500;
+
+      logger.error('Testing custom error:', customError);
+
+      const logCall = consoleSpy.error.mock.calls[0][0];
+      expect(logCall).toContain('Error: Custom error message');
+      expect(logCall).toContain('at '); // Stack trace should be present
+    });
+
+    it('should handle nested Error objects within other objects', () => {
+      const logger = new Logger('test', 'debug');
+      const errorEvent = {
+        error: new Error('WebSocket connection failed'),
+        type: 'error',
+        target: '[WebSocket object]',
+      };
+
+      logger.error('ErrorEvent:', errorEvent);
+
+      const logCall = consoleSpy.error.mock.calls[0][0];
+      expect(logCall).toContain('ErrorEvent:');
+      expect(logCall).toContain('Error: WebSocket connection failed');
+      expect(logCall).toContain('"type":"error"');
+      expect(logCall).toContain('"target":"[WebSocket object]"');
+    });
+
+    it('should not serialize Error objects as empty objects', () => {
+      const logger = new Logger('test', 'debug');
+      const error = new Error('Should not be empty');
+
+      logger.error('Error:', error);
+
+      const logCall = consoleSpy.error.mock.calls[0][0];
+      expect(logCall).not.toContain('{}');
+      expect(logCall).toContain('Error: Should not be empty');
+    });
+  });
+
+  describe('Other object serialization', () => {
+    it('should handle objects that normally serialize to empty objects', () => {
+      const logger = new Logger('test', 'debug');
+      const emptySerializingObj = Object.create(null);
+      Object.defineProperty(emptySerializingObj, 'hiddenProp', {
+        value: 'hidden value',
+        enumerable: false,
+      });
+      emptySerializingObj.visibleProp = 'visible value';
+
+      logger.info('Object:', emptySerializingObj);
+
+      const logCall = consoleSpy.log.mock.calls[0][0];
+      expect(logCall).toContain('"visibleProp":"visible value"');
+      expect(logCall).not.toContain('{}');
+    });
+
+    it('should handle regular objects normally', () => {
+      const logger = new Logger('test', 'debug');
+      const regularObj = { name: 'test', value: 42 };
+
+      logger.info('Regular object:', regularObj);
+
+      const logCall = consoleSpy.log.mock.calls[0][0];
+      expect(logCall).toContain('{"name":"test","value":42}');
+    });
+
+    it('should handle null and undefined', () => {
+      const logger = new Logger('test', 'debug');
+
+      logger.info('Values:', null, undefined);
+
+      const logCall = consoleSpy.log.mock.calls[0][0];
+      expect(logCall).toContain('null undefined');
+    });
+  });
+
+  describe('WebSocket error scenario', () => {
+    it('should log WebSocket errors like console.log does', () => {
+      const logger = new Logger('@tvlabs/wdio-channel', 'debug');
+      const wsError = new Error('Unexpected server response: 403');
+
+      // Simulate the WebSocket error logging
+      logger.error('Socket error:', wsError);
+
+      const logCall = consoleSpy.error.mock.calls[0][0];
+
+      // Should contain timestamp
+      expect(logCall).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+      // Should contain log level
+      expect(logCall).toContain('ERROR');
+      // Should contain logger name
+      expect(logCall).toContain('@tvlabs/wdio-channel');
+      // Should contain the message
+      expect(logCall).toContain('Socket error:');
+      // Should contain the full error with stack trace
+      expect(logCall).toContain('Error: Unexpected server response: 403');
+      expect(logCall).toContain('at ');
+      // Should NOT be empty object
+      expect(logCall).not.toContain('{}');
+    });
+  });
+
+  describe('Log levels', () => {
+    it('should respect log levels', () => {
+      const logger = new Logger('test', 'warn');
+
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+      expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle silent log level', () => {
+      const logger = new Logger('test', 'silent');
+
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+      logger.trace('trace message');
+
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+      expect(consoleSpy.warn).not.toHaveBeenCalled();
+      expect(consoleSpy.error).not.toHaveBeenCalled();
+      expect(consoleSpy.trace).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
```js
2025-08-14T18:02:22.971Z ERROR @tvlabs/wdio-channel: Socket error: {}
```

```js
2025-08-14T18:23:57.748Z ERROR @tvlabs/wdio-channel: Socket error: Error: Unexpected server response: 403
    at ClientRequest.<anonymous> (/Users/davidlucia/dev/tvlabs/wdio-tvlabs-service/node_modules/ws/lib/websocket.js:913:7)
    at ClientRequest.emit (node:events:518:28)
    at ClientRequest.emit (node:domain:489:12)
    at HTTPParser.parserOnIncomingClient (node:_http_client:716:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)
    at TLSSocket.socketOnData (node:_http_client:558:22)
    at TLSSocket.emit (node:events:518:28)
    at TLSSocket.emit (node:domain:489:12)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
```