### PR TITLE
feat: support build upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ run();
 - **Required:** Yes
 - **Description:** TV Labs API key used for authentication to the platform
 
+### `buildPath`
+
+- **Type:** `string`
+- **Required:** No
+- **Description:** Path to the packaged build to use for the session. When provided, this will perform a build upload before the session is created, and sets the `tvlabs:build` capability to the newly created build ID. The build is uploaded under the organizations default App unless the `app` option is provided
+
+### `app`
+
+- **Type:** `string`
+- **Required:** No
+- **Description:** Slug of the App for build uploads. When provided in combination with `buildPath`, the build is uploaded under this specified App.
+
 ### `retries`
 
 - **Type:** `number`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvlabs/wdio-service",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "WebdriverIO service that provides a better integration into TV Labs",
   "author": "Regan Karlewicz <regan@tvlabs.ai>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint",
-    "test": "vitest --config vitest.config.ts --coverage",
+    "test": "vitest --config vitest.config.ts --coverage --run",
+    "test:watch": "vitest --config vitest.config.ts --coverage",
     "publish:dry": "npm publish --access public --provenance --dry-run"
   },
   "type": "module",

--- a/src/channels/base.ts
+++ b/src/channels/base.ts
@@ -1,0 +1,110 @@
+import { WebSocket } from 'ws';
+import { Socket, type Channel } from 'phoenix';
+import { SevereServiceError } from 'webdriverio';
+import { Logger } from '../logger.js';
+import { getServiceInfo } from '../utils.js';
+
+import type { TVLabsSocketParams, LogLevel } from '../types.js';
+import type { PhoenixChannelJoinResponse } from '../phoenix.js';
+
+export abstract class BaseChannel {
+  protected socket: Socket;
+  protected log: Logger;
+
+  constructor(
+    protected endpoint: string,
+    protected maxReconnectRetries: number,
+    protected key: string,
+    protected logLevel: LogLevel = 'info',
+    loggerName: string,
+  ) {
+    this.log = new Logger(loggerName, this.logLevel);
+
+    this.socket = new Socket(this.endpoint, {
+      transport: WebSocket,
+      params: this.params(),
+      reconnectAfterMs: this.reconnectAfterMs.bind(this),
+    });
+
+    this.socket.onError((...args) =>
+      BaseChannel.logSocketError(this.log, ...args),
+    );
+  }
+
+  abstract connect(): Promise<void>;
+  abstract disconnect(): Promise<void>;
+
+  protected async join(topic: Channel): Promise<void> {
+    return new Promise((res, rej) => {
+      topic
+        .join()
+        .receive('ok', (_resp: PhoenixChannelJoinResponse) => {
+          res();
+        })
+        .receive('error', ({ response }: PhoenixChannelJoinResponse) => {
+          rej('Failed to join topic: ' + response);
+        })
+        .receive('timeout', () => {
+          rej('timeout');
+        });
+    });
+  }
+
+  protected async push<T>(
+    topic: Channel,
+    event: string,
+    payload: object,
+  ): Promise<T> {
+    return new Promise((res, rej) => {
+      topic
+        .push(event, payload)
+        .receive('ok', (msg: T) => {
+          res(msg);
+        })
+        .receive('error', (reason: string) => {
+          rej(reason);
+        })
+        .receive('timeout', () => {
+          rej('timeout');
+        });
+    });
+  }
+
+  private params(): TVLabsSocketParams {
+    const serviceInfo = getServiceInfo();
+
+    this.log.debug('Info:', serviceInfo);
+
+    return {
+      ...serviceInfo,
+      api_key: this.key,
+    };
+  }
+
+  private reconnectAfterMs(tries: number) {
+    if (tries > this.maxReconnectRetries) {
+      throw new SevereServiceError(
+        'Could not connect to TV Labs, please check your connection.',
+      );
+    }
+
+    const wait = [0, 1000, 3000, 5000][tries] || 10000;
+
+    this.log.info(
+      `[${tries}/${this.maxReconnectRetries}] Waiting ${wait}ms before re-attempting to connect...`,
+    );
+
+    return wait;
+  }
+
+  private static logSocketError(
+    log: Logger,
+    event: ErrorEvent,
+    _transport: new (endpoint: string) => object,
+    _establishedConnections: number,
+  ) {
+    const error = event.error;
+
+    log.error('Socket error:', error || event);
+  }
+}

--- a/src/channels/build.ts
+++ b/src/channels/build.ts
@@ -103,8 +103,9 @@ export class BuildChannel extends BaseChannel {
           'Content-Type': metadata.type,
           'Content-Length': String(metadata.size),
         },
-        // Can we use a stream here?
-        body: fs.readFileSync(filePath),
+        // @ts-expect-error - FIXME: fetch types are incorrect
+        body: fs.createReadStream(filePath),
+        duplex: 'half',
       });
 
       if (!response.ok) {

--- a/src/channels/build.ts
+++ b/src/channels/build.ts
@@ -1,0 +1,238 @@
+import { WebSocket } from 'ws';
+import { Socket, type Channel } from 'phoenix';
+import { SevereServiceError } from 'webdriverio';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { Logger } from '../logger.js';
+import { getServiceInfo } from '../utils.js';
+
+import type {
+  TVLabsSocketParams,
+  TVLabsExtractBuildInfoResponse,
+  TVLabsRequestUploadUrlResponse,
+  TVLabsBuildMetadata,
+  LogLevel,
+} from '../types.js';
+import type { PhoenixChannelJoinResponse } from '../phoenix.js';
+
+export class BuildChannel {
+  private socket: Socket;
+  private lobbyTopic: Channel;
+  private log: Logger;
+
+  constructor(
+    private endpoint: string,
+    private maxReconnectRetries: number,
+    private key: string,
+    private logLevel: LogLevel = 'info',
+  ) {
+    this.log = new Logger('@tvlabs/build-channel', this.logLevel);
+
+    this.socket = new Socket(this.endpoint, {
+      transport: WebSocket,
+      params: this.params(),
+      reconnectAfterMs: this.reconnectAfterMs.bind(this),
+    });
+
+    this.socket.onError((...args) =>
+      BuildChannel.logSocketError(this.log, ...args),
+    );
+
+    this.lobbyTopic = this.socket.channel('upload:lobby');
+  }
+
+  async disconnect(): Promise<void> {
+    return new Promise((res, _rej) => {
+      this.lobbyTopic.leave();
+      this.socket.disconnect(() => res());
+    });
+  }
+
+  async connect(): Promise<void> {
+    try {
+      this.log.debug('Connecting to TV Labs...');
+
+      this.socket.connect();
+
+      await this.join(this.lobbyTopic);
+
+      this.log.debug('Connected to TV Labs!');
+    } catch (error) {
+      this.log.error('Error connecting to TV Labs:', error);
+      throw new SevereServiceError(
+        'Could not connect to TV Labs, please check your connection.',
+      );
+    }
+  }
+
+  async uploadBuild(buildPath: string, appSlug?: string): Promise<string> {
+    const metadata = this.getFileMetadata(buildPath);
+
+    this.log.info(
+      `Requesting upload for build ${metadata.filename} (${metadata.type}, ${metadata.size} bytes)`,
+    );
+
+    const { url, build_id } = await this.requestUploadUrl(metadata, appSlug);
+
+    await this.uploadToUrl(url, buildPath, metadata);
+
+    await this.extractBuildInfo();
+
+    return build_id;
+  }
+
+  private async requestUploadUrl(
+    metadata: TVLabsBuildMetadata,
+    appSlug: string | undefined,
+  ) {
+    try {
+      return this.push<TVLabsRequestUploadUrlResponse>(
+        this.lobbyTopic,
+        'request_upload_url',
+        { metadata, application_slug: appSlug },
+      );
+    } catch (error) {
+      this.log.error('Failed to request upload URL:', error);
+      throw new SevereServiceError('Could not request upload URL');
+    }
+  }
+
+  private async uploadToUrl(
+    url: string,
+    filePath: string,
+    metadata: TVLabsBuildMetadata,
+  ): Promise<void> {
+    this.log.info('Uploading build...');
+
+    const contents = fs.readFileSync(filePath);
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': metadata.type,
+        'Content-Length': String(metadata.size),
+      },
+      body: contents,
+    });
+
+    if (!response.ok && !(response.status >= 200 && response.status < 300)) {
+      const body = await response.text().catch(() => '');
+      this.log.error('Upload failed', response.status, body);
+      throw new SevereServiceError('Failed to upload build to storage');
+    }
+
+    this.log.info('Upload complete');
+  }
+
+  private async extractBuildInfo(): Promise<void> {
+    this.log.info('Notifying TV Labs to process uploaded build...');
+
+    try {
+      const { application_id } =
+        await this.push<TVLabsExtractBuildInfoResponse>(
+          this.lobbyTopic,
+          'extract_build_info',
+          {},
+        );
+
+      this.log.info(`Build ${application_id} processed successfully`);
+    } catch (error) {
+      this.log.error('Build processing failed:', error);
+      throw new SevereServiceError('Build processing failed');
+    }
+  }
+
+  private async join(topic: Channel): Promise<void> {
+    return new Promise((res, rej) => {
+      topic
+        .join()
+        .receive('ok', (_resp: PhoenixChannelJoinResponse) => {
+          res();
+        })
+        .receive('error', ({ response }: PhoenixChannelJoinResponse) => {
+          rej('Failed to join topic: ' + response);
+        })
+        .receive('timeout', () => {
+          rej('timeout');
+        });
+    });
+  }
+
+  private async push<T>(
+    topic: Channel,
+    event: string,
+    payload: object,
+  ): Promise<T> {
+    return new Promise((res, rej) => {
+      topic
+        .push(event, payload)
+        .receive('ok', (msg: T) => {
+          res(msg);
+        })
+        .receive('error', (reason: string) => {
+          rej(reason);
+        })
+        .receive('timeout', () => {
+          rej('timeout');
+        });
+    });
+  }
+
+  private params(): TVLabsSocketParams {
+    const serviceInfo = getServiceInfo();
+
+    this.log.debug('Info:', serviceInfo);
+
+    return {
+      ...serviceInfo,
+      api_key: this.key,
+    };
+  }
+
+  private reconnectAfterMs(tries: number) {
+    if (tries > this.maxReconnectRetries) {
+      throw new SevereServiceError(
+        'Could not connect to TV Labs, please check your connection.',
+      );
+    }
+
+    const wait = [0, 1000, 3000, 5000][tries] || 10000;
+
+    this.log.info(
+      `[${tries}/${this.maxReconnectRetries}] Waiting ${wait}ms before re-attempting to connect...`,
+    );
+
+    return wait;
+  }
+
+  private static logSocketError(
+    log: Logger,
+    event: ErrorEvent,
+    _transport: new (endpoint: string) => object,
+    _establishedConnections: number,
+  ) {
+    const error = event.error;
+
+    log.error('Socket error:', error || event);
+  }
+
+  private getFileMetadata(buildPath: string): TVLabsBuildMetadata {
+    const filename = path.basename(buildPath);
+    const size = fs.statSync(buildPath).size;
+    const type = this.detectMimeType(filename);
+    return { filename, type, size };
+  }
+
+  private detectMimeType(filename: string): string {
+    const ext = path.extname(filename).toLowerCase();
+    switch (ext) {
+      case '.apk':
+        return 'application/vnd.android.package-archive';
+      case '.zip':
+        return 'application/zip';
+      default:
+        return 'application/octet-stream';
+    }
+  }
+}

--- a/src/channels/build.ts
+++ b/src/channels/build.ts
@@ -1,44 +1,33 @@
-import { WebSocket } from 'ws';
-import { Socket, type Channel } from 'phoenix';
+import { type Channel } from 'phoenix';
 import { SevereServiceError } from 'webdriverio';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { Logger } from '../logger.js';
-import { getServiceInfo } from '../utils.js';
+import { BaseChannel } from './base.js';
 
 import type {
-  TVLabsSocketParams,
   TVLabsExtractBuildInfoResponse,
   TVLabsRequestUploadUrlResponse,
   TVLabsBuildMetadata,
   LogLevel,
 } from '../types.js';
-import type { PhoenixChannelJoinResponse } from '../phoenix.js';
 
-export class BuildChannel {
-  private socket: Socket;
+export class BuildChannel extends BaseChannel {
   private lobbyTopic: Channel;
-  private log: Logger;
 
   constructor(
-    private endpoint: string,
-    private maxReconnectRetries: number,
-    private key: string,
-    private logLevel: LogLevel = 'info',
+    endpoint: string,
+    maxReconnectRetries: number,
+    key: string,
+    logLevel: LogLevel = 'info',
   ) {
-    this.log = new Logger('@tvlabs/build-channel', this.logLevel);
-
-    this.socket = new Socket(this.endpoint, {
-      transport: WebSocket,
-      params: this.params(),
-      reconnectAfterMs: this.reconnectAfterMs.bind(this),
-    });
-
-    this.socket.onError((...args) =>
-      BuildChannel.logSocketError(this.log, ...args),
+    super(
+      endpoint,
+      maxReconnectRetries,
+      key,
+      logLevel,
+      '@tvlabs/build-channel',
     );
-
     this.lobbyTopic = this.socket.channel('upload:lobby');
   }
 
@@ -144,80 +133,6 @@ export class BuildChannel {
       this.log.error('Error processing build:', error);
       throw error;
     }
-  }
-
-  private async join(topic: Channel): Promise<void> {
-    return new Promise((res, rej) => {
-      topic
-        .join()
-        .receive('ok', (_resp: PhoenixChannelJoinResponse) => {
-          res();
-        })
-        .receive('error', ({ response }: PhoenixChannelJoinResponse) => {
-          rej('Failed to join topic: ' + response);
-        })
-        .receive('timeout', () => {
-          rej('timeout');
-        });
-    });
-  }
-
-  private async push<T>(
-    topic: Channel,
-    event: string,
-    payload: object,
-  ): Promise<T> {
-    return new Promise((res, rej) => {
-      topic
-        .push(event, payload)
-        .receive('ok', (msg: T) => {
-          res(msg);
-        })
-        .receive('error', (reason: string) => {
-          rej(reason);
-        })
-        .receive('timeout', () => {
-          rej('timeout');
-        });
-    });
-  }
-
-  private params(): TVLabsSocketParams {
-    const serviceInfo = getServiceInfo();
-
-    this.log.debug('Info:', serviceInfo);
-
-    return {
-      ...serviceInfo,
-      api_key: this.key,
-    };
-  }
-
-  private reconnectAfterMs(tries: number) {
-    if (tries > this.maxReconnectRetries) {
-      throw new SevereServiceError(
-        'Could not connect to TV Labs, please check your connection.',
-      );
-    }
-
-    const wait = [0, 1000, 3000, 5000][tries] || 10000;
-
-    this.log.info(
-      `[${tries}/${this.maxReconnectRetries}] Waiting ${wait}ms before re-attempting to connect...`,
-    );
-
-    return wait;
-  }
-
-  private static logSocketError(
-    log: Logger,
-    event: ErrorEvent,
-    _transport: new (endpoint: string) => object,
-    _establishedConnections: number,
-  ) {
-    const error = event.error;
-
-    log.error('Socket error:', error || event);
   }
 
   private getFileMetadata(buildPath: string): TVLabsBuildMetadata {

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -1,23 +1,17 @@
-import { WebSocket } from 'ws';
-import { Socket, type Channel } from 'phoenix';
+import { type Channel } from 'phoenix';
 import { SevereServiceError } from 'webdriverio';
-import { Logger } from '../logger.js';
-import { getServiceInfo } from '../utils.js';
+import { BaseChannel } from './base.js';
 
 import type {
   TVLabsCapabilities,
-  TVLabsSocketParams,
   TVLabsSessionRequestEventHandler,
   TVLabsSessionRequestResponse,
   LogLevel,
 } from '../types.js';
-import type { PhoenixChannelJoinResponse } from '../phoenix.js';
 
-export class SessionChannel {
-  private socket: Socket;
+export class SessionChannel extends BaseChannel {
   private lobbyTopic: Channel;
   private requestTopic?: Channel;
-  private log: Logger;
 
   private readonly events = {
     SESSION_READY: 'session:ready',
@@ -29,22 +23,18 @@ export class SessionChannel {
   } as const;
 
   constructor(
-    private endpoint: string,
-    private maxReconnectRetries: number,
-    private key: string,
-    private logLevel: LogLevel = 'info',
+    endpoint: string,
+    maxReconnectRetries: number,
+    key: string,
+    logLevel: LogLevel = 'info',
   ) {
-    this.log = new Logger('@tvlabs/session-channel', this.logLevel);
-    this.socket = new Socket(this.endpoint, {
-      transport: WebSocket,
-      params: this.params(),
-      reconnectAfterMs: this.reconnectAfterMs.bind(this),
-    });
-
-    this.socket.onError((...args) =>
-      SessionChannel.logSocketError(this.log, ...args),
+    super(
+      endpoint,
+      maxReconnectRetries,
+      key,
+      logLevel,
+      '@tvlabs/session-channel',
     );
-
     this.lobbyTopic = this.socket.channel('requests:lobby');
   }
 
@@ -193,79 +183,7 @@ export class SessionChannel {
     }
   }
 
-  private async join(topic: Channel): Promise<void> {
-    return new Promise((res, rej) => {
-      topic
-        .join()
-        .receive('ok', (_resp: PhoenixChannelJoinResponse) => {
-          res();
-        })
-        .receive('error', ({ response }: PhoenixChannelJoinResponse) => {
-          rej('Failed to join topic: ' + response);
-        })
-        .receive('timeout', () => {
-          rej('timeout');
-        });
-    });
-  }
-
-  private async push<T>(
-    topic: Channel,
-    event: string,
-    payload: object,
-  ): Promise<T> {
-    return new Promise((res, rej) => {
-      topic
-        .push(event, payload)
-        .receive('ok', (msg: T) => {
-          res(msg);
-        })
-        .receive('error', (reason: string) => {
-          rej(reason);
-        })
-        .receive('timeout', () => {
-          rej('timeout');
-        });
-    });
-  }
-
-  private params(): TVLabsSocketParams {
-    const serviceInfo = getServiceInfo();
-
-    this.log.debug('Info:', serviceInfo);
-
-    return {
-      ...serviceInfo,
-      api_key: this.key,
-    };
-  }
-
-  private reconnectAfterMs(tries: number) {
-    if (tries > this.maxReconnectRetries) {
-      throw new SevereServiceError(
-        'Could not connect to TV Labs, please check your connection.',
-      );
-    }
-
-    const wait = [0, 1000, 3000, 5000][tries] || 10000;
-
-    this.log.info(
-      `[${tries}/${this.maxReconnectRetries}] Waiting ${wait}ms before re-attempting to connect...`,
-    );
-
-    return wait;
-  }
-
   private tvlabsSessionLink(sessionId: string) {
     return `https://tvlabs.ai/app/sessions/${sessionId}`;
-  }
-
-  private static logSocketError(
-    log: Logger,
-    event: ErrorEvent,
-    _transport: new (endpoint: string) => object,
-    _establishedConnections: number,
-  ) {
-    log.error('Socket error:', event.error);
   }
 }

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -58,17 +58,17 @@ export class SessionChannel {
 
   async connect(): Promise<void> {
     try {
-      this.log.debug('Connecting to TV Labs...');
+      this.log.debug('Connecting to session channel...');
 
       this.socket.connect();
 
       await this.join(this.lobbyTopic);
 
-      this.log.debug('Connected to TV Labs!');
+      this.log.debug('Connected to session channel!');
     } catch (error) {
-      this.log.error('Error connecting to TV Labs:', error);
+      this.log.error('Error connecting to session channel:', error);
       throw new SevereServiceError(
-        'Could not connect to TV Labs, please check your connection.',
+        'Could not connect to session channel, please check your connection.',
       );
     }
   }

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -1,8 +1,8 @@
 import { WebSocket } from 'ws';
 import { Socket, type Channel } from 'phoenix';
 import { SevereServiceError } from 'webdriverio';
-import { Logger } from './logger.js';
-import { getServiceInfo } from './utils.js';
+import { Logger } from '../logger.js';
+import { getServiceInfo } from '../utils.js';
 
 import type {
   TVLabsCapabilities,
@@ -10,10 +10,10 @@ import type {
   TVLabsSessionRequestEventHandler,
   TVLabsSessionRequestResponse,
   LogLevel,
-} from './types.js';
-import type { PhoenixChannelJoinResponse } from './phoenix.js';
+} from '../types.js';
+import type { PhoenixChannelJoinResponse } from '../phoenix.js';
 
-export class TVLabsChannel {
+export class SessionChannel {
   private socket: Socket;
   private lobbyTopic: Channel;
   private requestTopic?: Channel;
@@ -34,7 +34,7 @@ export class TVLabsChannel {
     private key: string,
     private logLevel: LogLevel = 'info',
   ) {
-    this.log = new Logger('@tvlabs/wdio-channel', this.logLevel);
+    this.log = new Logger('@tvlabs/session-channel', this.logLevel);
     this.socket = new Socket(this.endpoint, {
       transport: WebSocket,
       params: this.params(),
@@ -42,7 +42,7 @@ export class TVLabsChannel {
     });
 
     this.socket.onError((...args) =>
-      TVLabsChannel.logSocketError(this.log, ...args),
+      SessionChannel.logSocketError(this.log, ...args),
     );
 
     this.lobbyTopic = this.socket.channel('requests:lobby');

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,4 +66,5 @@ export type TVLabsBuildMetadata = {
   filename: string;
   type: string;
   size: number;
+  sha256: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,11 @@ export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent';
 
 export type TVLabsServiceOptions = {
   apiKey: string;
-  endpoint?: string;
+  sessionEndpoint?: string;
+  buildEndpoint?: string;
   retries?: number;
+  buildPath?: string;
+  app?: string;
   reconnectRetries?: number;
   attachRequestId?: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,3 +52,18 @@ export type TVLabsServiceInfo = {
   service_version: string;
   service_name: string;
 };
+
+export type TVLabsRequestUploadUrlResponse = {
+  url: string;
+  build_id: string;
+};
+
+export type TVLabsExtractBuildInfoResponse = {
+  application_id: string;
+};
+
+export type TVLabsBuildMetadata = {
+  filename: string;
+  type: string;
+  size: number;
+};

--- a/test/channels/build.test.ts
+++ b/test/channels/build.test.ts
@@ -1,0 +1,550 @@
+import * as phoenix from 'phoenix';
+import * as fs from 'node:fs';
+import { randomUUID } from 'crypto';
+import { BuildChannel } from '../../src/channels/build.js';
+import { SevereServiceError } from 'webdriverio';
+
+const fakeEndpoint = 'ws://localhost:12345';
+const fakeApiKey = 'my-api-key';
+const reconnectRetries = 5;
+const testBuildPath = '/path/to/test.apk';
+const testAppSlug = 'test-app';
+
+vi.stubGlobal('fetch', vi.fn());
+
+vi.mock('phoenix', () => {
+  return {
+    Socket: vi.fn().mockImplementation(() => fakeSocket),
+  };
+});
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  statSync: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockReceive('ok', {});
+
+  vi.mocked(fs.statSync).mockReturnValue({ size: 1024 } as fs.Stats);
+  vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('fake-file-content'));
+
+  vi.mocked(fetch).mockResolvedValue({
+    ok: true,
+    status: 200,
+  } as Response);
+});
+
+describe('Build Channel', () => {
+  it('should be a function', () => {
+    expect(BuildChannel).toBeInstanceOf(Function);
+  });
+
+  it('can be instantiated', () => {
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    expect(channel).toBeInstanceOf(BuildChannel);
+  });
+
+  it('calls connect and join on connect', async () => {
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    expect(vi.mocked(phoenix.Socket)).toHaveBeenCalledWith(
+      fakeEndpoint,
+      expect.objectContaining({
+        params: {
+          api_key: fakeApiKey,
+          service_version: expect.not.stringMatching('unknown'),
+          service_name: '@tvlabs/wdio-service',
+        },
+      }),
+    );
+    expect(fakeSocket.connect).toHaveBeenCalledOnce();
+    expect(fakeChannel.join).toHaveBeenCalled();
+  });
+
+  it('can upload a build successfully', async () => {
+    const buildId = randomUUID();
+    const uploadUrl = 'https://storage.example.com/upload';
+    const applicationId = 'com.example.app';
+
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    // Mock push responses in order
+    let pushCallCount = 0;
+    fakeChannel.push.mockImplementation((event) => {
+      pushCallCount++;
+
+      if (event === 'request_upload_url' && pushCallCount === 1) {
+        return {
+          receive: vi.fn().mockImplementation((type, callback) => {
+            if (type === 'ok') {
+              // Immediately call the callback
+              callback({ url: uploadUrl, build_id: buildId });
+            }
+            return { receive: vi.fn().mockReturnThis() };
+          }),
+        };
+      }
+
+      if (event === 'extract_build_info' && pushCallCount === 2) {
+        return {
+          receive: vi.fn().mockImplementation((type, callback) => {
+            if (type === 'ok') {
+              // Immediately call the callback
+              callback({ application_id: applicationId });
+            }
+            return { receive: vi.fn().mockReturnThis() };
+          }),
+        };
+      }
+
+      return {
+        receive: vi.fn().mockReturnThis(),
+      };
+    });
+
+    const result = await channel.uploadBuild(testBuildPath, testAppSlug);
+
+    expect(result).toEqual(buildId);
+
+    // Verify request_upload_url was called with correct metadata
+    expect(fakeChannel.push).toHaveBeenCalledWith(
+      'request_upload_url',
+      expect.objectContaining({
+        metadata: {
+          filename: 'test.apk',
+          type: 'application/vnd.android.package-archive',
+          size: 1024,
+        },
+        application_slug: testAppSlug,
+      }),
+    );
+
+    // Verify extract_build_info was called
+    expect(fakeChannel.push).toHaveBeenCalledWith('extract_build_info', {});
+
+    // Verify file was uploaded to the URL
+    expect(fetch).toHaveBeenCalledWith(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/vnd.android.package-archive',
+        'Content-Length': '1024',
+      },
+      body: expect.any(Buffer),
+    });
+  });
+
+  it('can upload a build without app slug', async () => {
+    const buildId = randomUUID();
+    const uploadUrl = 'https://storage.example.com/upload';
+    const applicationId = 'com.example.app';
+
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    // Mock push responses
+    let pushCallCount = 0;
+    fakeChannel.push.mockImplementation((event) => {
+      pushCallCount++;
+
+      if (event === 'request_upload_url' && pushCallCount === 1) {
+        return {
+          receive: vi.fn().mockImplementation((type, callback) => {
+            if (type === 'ok') {
+              callback({ url: uploadUrl, build_id: buildId });
+            }
+            return { receive: vi.fn().mockReturnThis() };
+          }),
+        };
+      }
+
+      if (event === 'extract_build_info' && pushCallCount === 2) {
+        return {
+          receive: vi.fn().mockImplementation((type, callback) => {
+            if (type === 'ok') {
+              callback({ application_id: applicationId });
+            }
+            return { receive: vi.fn().mockReturnThis() };
+          }),
+        };
+      }
+
+      return {
+        receive: vi.fn().mockReturnThis(),
+      };
+    });
+
+    const result = await channel.uploadBuild(testBuildPath);
+
+    expect(result).toEqual(buildId);
+
+    expect(fakeChannel.push).toHaveBeenCalledWith(
+      'request_upload_url',
+      expect.objectContaining({
+        metadata: {
+          filename: 'test.apk',
+          type: 'application/vnd.android.package-archive',
+          size: 1024,
+        },
+        application_slug: undefined,
+      }),
+    );
+  });
+
+  it('detects correct MIME types for different file extensions', async () => {
+    const buildId = randomUUID();
+    const uploadUrl = 'https://storage.example.com/upload';
+    const applicationId = 'com.example.app';
+
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    // Mock successful responses for both calls
+    fakeChannel.push.mockImplementation(() => ({
+      receive: vi.fn().mockImplementation((type, callback) => {
+        if (type === 'ok') {
+          callback({
+            url: uploadUrl,
+            build_id: buildId,
+            application_id: applicationId,
+          });
+        }
+        return { receive: vi.fn().mockReturnThis() };
+      }),
+    }));
+
+    // Test .zip file
+    await channel.uploadBuild('/path/to/test.zip');
+    expect(fakeChannel.push).toHaveBeenCalledWith(
+      'request_upload_url',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          type: 'application/zip',
+        }),
+      }),
+    );
+
+    // Reset and test unknown extension
+    vi.clearAllMocks();
+    mockReceive('ok', {});
+    fakeChannel.push.mockImplementation(() => ({
+      receive: vi.fn().mockImplementation((type, callback) => {
+        if (type === 'ok') {
+          callback({
+            url: uploadUrl,
+            build_id: buildId,
+            application_id: applicationId,
+          });
+        }
+        return { receive: vi.fn().mockReturnThis() };
+      }),
+    }));
+
+    await channel.uploadBuild('/path/to/test.unknown');
+    expect(fakeChannel.push).toHaveBeenCalledWith(
+      'request_upload_url',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          type: 'application/octet-stream',
+        }),
+      }),
+    );
+  });
+
+  it('raises on failed lobby topic join', async () => {
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    mockReceive('error', { response: 'unknown error' });
+
+    await expect(() => channel.connect()).rejects.toThrow(SevereServiceError);
+  });
+
+  it('raises on topic join timeout', async () => {
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    mockReceive('timeout', {});
+
+    await expect(() => channel.connect()).rejects.toThrow(SevereServiceError);
+  });
+
+  it('raises on upload URL request timeout', async () => {
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    const mockReceiveChain = {
+      receive: vi
+        .fn()
+        .mockImplementation((type: string, callback: () => void) => {
+          if (type === 'timeout') {
+            // Call the callback immediately to trigger the timeout behavior
+            callback();
+          }
+          return mockReceiveChain;
+        }),
+    };
+
+    fakeChannel.push.mockImplementation(() => mockReceiveChain);
+
+    await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
+  });
+
+  it('raises on upload URL request error', async () => {
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    const mockReceiveChain = {
+      receive: vi
+        .fn()
+        .mockImplementation(
+          (type: string, callback: (reason: string) => void) => {
+            if (type === 'error') {
+              // Call the callback immediately to trigger the error behavior
+              callback('Mock error');
+            }
+            return mockReceiveChain;
+          },
+        ),
+    };
+
+    fakeChannel.push.mockImplementation(() => mockReceiveChain);
+
+    await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
+  });
+
+  it('raises on failed file upload to storage', async () => {
+    const buildId = randomUUID();
+    const uploadUrl = 'https://storage.example.com/upload';
+
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    // Mock successful request_upload_url
+    fakeChannel.push.mockImplementation(() => ({
+      receive: vi.fn().mockImplementation((type, callback) => {
+        if (type === 'ok') {
+          callback({ url: uploadUrl, build_id: buildId });
+        }
+        return { receive: vi.fn().mockReturnThis() };
+      }),
+    }));
+
+    // Mock failed upload
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow(
+      SevereServiceError,
+    );
+  });
+
+  it('raises on extract build info timeout', async () => {
+    const buildId = randomUUID();
+    const uploadUrl = 'https://storage.example.com/upload';
+
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    // Mock responses: successful upload URL, then timeout on extract
+    let pushCallCount = 0;
+    fakeChannel.push.mockImplementation((event) => {
+      pushCallCount++;
+
+      if (event === 'request_upload_url' && pushCallCount === 1) {
+        return {
+          receive: vi.fn().mockImplementation((type, callback) => {
+            if (type === 'ok') {
+              callback({ url: uploadUrl, build_id: buildId });
+            }
+            return { receive: vi.fn().mockReturnThis() };
+          }),
+        };
+      }
+
+      if (event === 'extract_build_info' && pushCallCount === 2) {
+        const mockReceiveChain = {
+          receive: vi
+            .fn()
+            .mockImplementation((type: string, callback: () => void) => {
+              if (type === 'timeout') {
+                callback();
+              }
+              return mockReceiveChain;
+            }),
+        };
+        return mockReceiveChain;
+      }
+
+      return {
+        receive: vi.fn().mockReturnThis(),
+      };
+    });
+
+    await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
+  });
+
+  it('raises on extract build info error', async () => {
+    const buildId = randomUUID();
+    const uploadUrl = 'https://storage.example.com/upload';
+
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    // Mock responses: successful upload URL, then error on extract
+    let pushCallCount = 0;
+    fakeChannel.push.mockImplementation((event) => {
+      pushCallCount++;
+
+      if (event === 'request_upload_url' && pushCallCount === 1) {
+        return {
+          receive: vi.fn().mockImplementation((type, callback) => {
+            if (type === 'ok') {
+              callback({ url: uploadUrl, build_id: buildId });
+            }
+            return { receive: vi.fn().mockReturnThis() };
+          }),
+        };
+      }
+
+      if (event === 'extract_build_info' && pushCallCount === 2) {
+        const mockReceiveChain = {
+          receive: vi
+            .fn()
+            .mockImplementation(
+              (type: string, callback: (reason: string) => void) => {
+                if (type === 'error') {
+                  callback('Mock error');
+                }
+                return mockReceiveChain;
+              },
+            ),
+        };
+        return mockReceiveChain;
+      }
+
+      return {
+        receive: vi.fn().mockReturnThis(),
+      };
+    });
+
+    await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
+  });
+
+  it('raises on fetch network error', async () => {
+    const buildId = randomUUID();
+    const uploadUrl = 'https://storage.example.com/upload';
+
+    const channel = new BuildChannel(
+      fakeEndpoint,
+      reconnectRetries,
+      fakeApiKey,
+    );
+
+    await channel.connect();
+
+    // Mock successful request_upload_url
+    fakeChannel.push.mockImplementation(() => ({
+      receive: vi.fn().mockImplementation((type, callback) => {
+        if (type === 'ok') {
+          callback({ url: uploadUrl, build_id: buildId });
+        }
+        return { receive: vi.fn().mockReturnThis() };
+      }),
+    }));
+
+    // Mock network error
+    vi.mocked(fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
+  });
+});
+
+const fakeChannel = {
+  join: vi.fn().mockReturnThis(),
+  push: vi.fn().mockReturnThis(),
+  leave: vi.fn().mockReturnThis(),
+  receive: vi.fn().mockImplementation((event, callback) => {
+    if (event === 'ok') {
+      callback({});
+    }
+    return fakeChannel;
+  }),
+};
+
+const fakeSocket = {
+  connect: vi.fn(),
+  channel: vi.fn(() => fakeChannel),
+  onError: vi.fn(),
+  disconnect: vi.fn((callback?: () => void) => callback?.()),
+};
+
+function mockReceive(event: string, response: object) {
+  fakeChannel.receive.mockImplementation((e, callback) => {
+    if (e === event) {
+      callback(response);
+    }
+    return fakeChannel;
+  });
+}

--- a/test/channels/build.test.ts
+++ b/test/channels/build.test.ts
@@ -100,7 +100,6 @@ describe('Build Channel', () => {
 
     expect(result).toEqual(buildId);
 
-    // Verify request_upload_url was called with correct metadata
     expect(fakeChannel.push).toHaveBeenCalledWith(
       'request_upload_url',
       expect.objectContaining({
@@ -113,7 +112,6 @@ describe('Build Channel', () => {
       }),
     );
 
-    // Verify file was uploaded to the URL
     expect(fetch).toHaveBeenCalledWith(uploadUrl, {
       method: 'PUT',
       headers: {
@@ -123,7 +121,6 @@ describe('Build Channel', () => {
       body: expect.any(Buffer),
     });
 
-    // Verify extract_build_info was called
     expect(fakeChannel.push).toHaveBeenCalledWith('extract_build_info', {});
   });
 
@@ -164,7 +161,6 @@ describe('Build Channel', () => {
       }),
     );
 
-    // Verify file was uploaded to the URL
     expect(fetch).toHaveBeenCalledWith(uploadUrl, {
       method: 'PUT',
       headers: {
@@ -174,7 +170,6 @@ describe('Build Channel', () => {
       body: expect.any(Buffer),
     });
 
-    // Verify extract_build_info was called
     expect(fakeChannel.push).toHaveBeenCalledWith('extract_build_info', {});
   });
 
@@ -422,7 +417,6 @@ describe('Build Channel', () => {
 
     mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
 
-    // Mock network error
     vi.mocked(fetch).mockRejectedValue(new Error('Network error'));
 
     await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();

--- a/test/channels/build.test.ts
+++ b/test/channels/build.test.ts
@@ -19,15 +19,20 @@ vi.mock('phoenix', () => {
 });
 
 vi.mock('node:fs', () => ({
-  readFileSync: vi.fn(),
   statSync: vi.fn(),
+  createReadStream: vi.fn(),
 }));
 
 beforeEach(() => {
   vi.clearAllMocks();
 
   vi.mocked(fs.statSync).mockReturnValue({ size: 1024 } as fs.Stats);
-  vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('fake-file-content'));
+
+  vi.mocked(fs.createReadStream).mockReturnValue({
+    pipe: vi.fn(),
+    on: vi.fn(),
+    read: vi.fn(),
+  } as unknown as fs.ReadStream);
 
   vi.mocked(fetch).mockResolvedValue({
     ok: true,
@@ -118,7 +123,8 @@ describe('Build Channel', () => {
         'Content-Type': 'application/vnd.android.package-archive',
         'Content-Length': '1024',
       },
-      body: expect.any(Buffer),
+      body: expect.any(Object),
+      duplex: 'half',
     });
 
     expect(fakeChannel.push).toHaveBeenCalledWith('extract_build_info', {});
@@ -167,7 +173,8 @@ describe('Build Channel', () => {
         'Content-Type': 'application/vnd.android.package-archive',
         'Content-Length': '1024',
       },
-      body: expect.any(Buffer),
+      body: expect.any(Object),
+      duplex: 'half',
     });
 
     expect(fakeChannel.push).toHaveBeenCalledWith('extract_build_info', {});

--- a/test/channels/build.test.ts
+++ b/test/channels/build.test.ts
@@ -87,39 +87,27 @@ describe('Build Channel', () => {
 
     await channel.connect();
 
-    // Mock push responses in order
-    let pushCallCount = 0;
-    fakeChannel.push.mockImplementation((event) => {
-      pushCallCount++;
-
-      if (event === 'request_upload_url' && pushCallCount === 1) {
+    fakeChannel.push
+      .mockImplementationOnce((_event) => {
         return {
           receive: vi.fn().mockImplementation((type, callback) => {
             if (type === 'ok') {
-              // Immediately call the callback
               callback({ url: uploadUrl, build_id: buildId });
             }
             return { receive: vi.fn().mockReturnThis() };
           }),
         };
-      }
-
-      if (event === 'extract_build_info' && pushCallCount === 2) {
+      })
+      .mockImplementationOnce((_event) => {
         return {
           receive: vi.fn().mockImplementation((type, callback) => {
             if (type === 'ok') {
-              // Immediately call the callback
               callback({ application_id: applicationId });
             }
             return { receive: vi.fn().mockReturnThis() };
           }),
         };
-      }
-
-      return {
-        receive: vi.fn().mockReturnThis(),
-      };
-    });
+      });
 
     const result = await channel.uploadBuild(testBuildPath, testAppSlug);
 
@@ -165,12 +153,8 @@ describe('Build Channel', () => {
 
     await channel.connect();
 
-    // Mock push responses
-    let pushCallCount = 0;
-    fakeChannel.push.mockImplementation((event) => {
-      pushCallCount++;
-
-      if (event === 'request_upload_url' && pushCallCount === 1) {
+    fakeChannel.push
+      .mockImplementationOnce((_event) => {
         return {
           receive: vi.fn().mockImplementation((type, callback) => {
             if (type === 'ok') {
@@ -179,9 +163,8 @@ describe('Build Channel', () => {
             return { receive: vi.fn().mockReturnThis() };
           }),
         };
-      }
-
-      if (event === 'extract_build_info' && pushCallCount === 2) {
+      })
+      .mockImplementationOnce((_event) => {
         return {
           receive: vi.fn().mockImplementation((type, callback) => {
             if (type === 'ok') {
@@ -190,12 +173,7 @@ describe('Build Channel', () => {
             return { receive: vi.fn().mockReturnThis() };
           }),
         };
-      }
-
-      return {
-        receive: vi.fn().mockReturnThis(),
-      };
-    });
+      });
 
     const result = await channel.uploadBuild(testBuildPath);
 
@@ -402,12 +380,8 @@ describe('Build Channel', () => {
 
     await channel.connect();
 
-    // Mock responses: successful upload URL, then timeout on extract
-    let pushCallCount = 0;
-    fakeChannel.push.mockImplementation((event) => {
-      pushCallCount++;
-
-      if (event === 'request_upload_url' && pushCallCount === 1) {
+    fakeChannel.push
+      .mockImplementationOnce((_event) => {
         return {
           receive: vi.fn().mockImplementation((type, callback) => {
             if (type === 'ok') {
@@ -416,9 +390,8 @@ describe('Build Channel', () => {
             return { receive: vi.fn().mockReturnThis() };
           }),
         };
-      }
-
-      if (event === 'extract_build_info' && pushCallCount === 2) {
+      })
+      .mockImplementationOnce((_event) => {
         const mockReceiveChain = {
           receive: vi
             .fn()
@@ -430,12 +403,7 @@ describe('Build Channel', () => {
             }),
         };
         return mockReceiveChain;
-      }
-
-      return {
-        receive: vi.fn().mockReturnThis(),
-      };
-    });
+      });
 
     await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
   });
@@ -452,12 +420,8 @@ describe('Build Channel', () => {
 
     await channel.connect();
 
-    // Mock responses: successful upload URL, then error on extract
-    let pushCallCount = 0;
-    fakeChannel.push.mockImplementation((event) => {
-      pushCallCount++;
-
-      if (event === 'request_upload_url' && pushCallCount === 1) {
+    fakeChannel.push
+      .mockImplementationOnce((_event) => {
         return {
           receive: vi.fn().mockImplementation((type, callback) => {
             if (type === 'ok') {
@@ -466,9 +430,8 @@ describe('Build Channel', () => {
             return { receive: vi.fn().mockReturnThis() };
           }),
         };
-      }
-
-      if (event === 'extract_build_info' && pushCallCount === 2) {
+      })
+      .mockImplementationOnce((_event) => {
         const mockReceiveChain = {
           receive: vi
             .fn()
@@ -482,12 +445,7 @@ describe('Build Channel', () => {
             ),
         };
         return mockReceiveChain;
-      }
-
-      return {
-        receive: vi.fn().mockReturnThis(),
-      };
-    });
+      });
 
     await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
   });

--- a/test/channels/build.test.ts
+++ b/test/channels/build.test.ts
@@ -25,7 +25,6 @@ vi.mock('node:fs', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockReceive('ok', {});
 
   vi.mocked(fs.statSync).mockReturnValue({ size: 1024 } as fs.Stats);
   vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('fake-file-content'));
@@ -58,6 +57,8 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
     expect(vi.mocked(phoenix.Socket)).toHaveBeenCalledWith(
@@ -85,29 +86,15 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    fakeChannel.push
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ url: uploadUrl, build_id: buildId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      })
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ application_id: applicationId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      });
+    // Request upload URL response
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
+
+    // Extract build info response
+    mockPushReceive('ok', { application_id: applicationId });
 
     const result = await channel.uploadBuild(testBuildPath, testAppSlug);
 
@@ -151,29 +138,15 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    fakeChannel.push
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ url: uploadUrl, build_id: buildId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      })
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ application_id: applicationId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      });
+    // Request upload URL response
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
+
+    // Extract build info response
+    mockPushReceive('ok', { application_id: applicationId });
 
     const result = await channel.uploadBuild(testBuildPath);
 
@@ -216,29 +189,15 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    fakeChannel.push
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ url: uploadUrl, build_id: buildId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      })
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ application_id: applicationId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      });
+    // Request upload URL response
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
+
+    // Extract build info response
+    mockPushReceive('ok', { application_id: applicationId });
 
     await channel.uploadBuild('/path/to/test.zip');
 
@@ -265,29 +224,15 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    fakeChannel.push
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ url: uploadUrl, build_id: buildId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      })
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ application_id: applicationId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      });
+    // Request upload URL response
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
+
+    // Extract build info response
+    mockPushReceive('ok', { application_id: applicationId });
 
     await channel.uploadBuild('/path/to/test.apk');
 
@@ -314,29 +259,15 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    fakeChannel.push
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ url: uploadUrl, build_id: buildId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      })
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ application_id: applicationId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      });
+    // Request upload URL response
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
+
+    // Extract build info response
+    mockPushReceive('ok', { application_id: applicationId });
 
     await channel.uploadBuild('/path/to/test.unknown');
 
@@ -359,7 +290,7 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
-    mockReceive('error', { response: 'unknown error' });
+    mockJoinReceive('error', { response: 'unknown error' });
 
     await expect(() => channel.connect()).rejects.toThrow(SevereServiceError);
   });
@@ -371,7 +302,7 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
-    mockReceive('timeout', {});
+    mockJoinReceive('timeout', {});
 
     await expect(() => channel.connect()).rejects.toThrow(SevereServiceError);
   });
@@ -383,21 +314,11 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    const mockReceiveChain = {
-      receive: vi
-        .fn()
-        .mockImplementation((type: string, callback: () => void) => {
-          if (type === 'timeout') {
-            // Call the callback immediately to trigger the timeout behavior
-            callback();
-          }
-          return mockReceiveChain;
-        }),
-    };
-
-    fakeChannel.push.mockImplementation(() => mockReceiveChain);
+    mockPushReceive('timeout', {});
 
     await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
   });
@@ -409,23 +330,11 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    const mockReceiveChain = {
-      receive: vi
-        .fn()
-        .mockImplementation(
-          (type: string, callback: (reason: string) => void) => {
-            if (type === 'error') {
-              // Call the callback immediately to trigger the error behavior
-              callback('Mock error');
-            }
-            return mockReceiveChain;
-          },
-        ),
-    };
-
-    fakeChannel.push.mockImplementation(() => mockReceiveChain);
+    mockPushReceive('error', { reason: 'Mock error' });
 
     await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
   });
@@ -440,17 +349,11 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    // Mock successful request_upload_url
-    fakeChannel.push.mockImplementation(() => ({
-      receive: vi.fn().mockImplementation((type, callback) => {
-        if (type === 'ok') {
-          callback({ url: uploadUrl, build_id: buildId });
-        }
-        return { receive: vi.fn().mockReturnThis() };
-      }),
-    }));
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
 
     // Mock failed upload
     vi.mocked(fetch).mockResolvedValue({
@@ -473,32 +376,12 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    fakeChannel.push
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ url: uploadUrl, build_id: buildId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      })
-      .mockImplementationOnce((_event) => {
-        const mockReceiveChain = {
-          receive: vi
-            .fn()
-            .mockImplementation((type: string, callback: () => void) => {
-              if (type === 'timeout') {
-                callback();
-              }
-              return mockReceiveChain;
-            }),
-        };
-        return mockReceiveChain;
-      });
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
+    mockPushReceive('timeout', {});
 
     await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
   });
@@ -513,34 +396,12 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    fakeChannel.push
-      .mockImplementationOnce((_event) => {
-        return {
-          receive: vi.fn().mockImplementation((type, callback) => {
-            if (type === 'ok') {
-              callback({ url: uploadUrl, build_id: buildId });
-            }
-            return { receive: vi.fn().mockReturnThis() };
-          }),
-        };
-      })
-      .mockImplementationOnce((_event) => {
-        const mockReceiveChain = {
-          receive: vi
-            .fn()
-            .mockImplementation(
-              (type: string, callback: (reason: string) => void) => {
-                if (type === 'error') {
-                  callback('Mock error');
-                }
-                return mockReceiveChain;
-              },
-            ),
-        };
-        return mockReceiveChain;
-      });
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
+    mockPushReceive('error', { reason: 'Mock error' });
 
     await expect(() => channel.uploadBuild(testBuildPath)).rejects.toThrow();
   });
@@ -555,17 +416,11 @@ describe('Build Channel', () => {
       fakeApiKey,
     );
 
+    mockJoinReceive('ok', {});
+
     await channel.connect();
 
-    // Mock successful request_upload_url
-    fakeChannel.push.mockImplementation(() => ({
-      receive: vi.fn().mockImplementation((type, callback) => {
-        if (type === 'ok') {
-          callback({ url: uploadUrl, build_id: buildId });
-        }
-        return { receive: vi.fn().mockReturnThis() };
-      }),
-    }));
+    mockPushReceive('ok', { url: uploadUrl, build_id: buildId });
 
     // Mock network error
     vi.mocked(fetch).mockRejectedValue(new Error('Network error'));
@@ -593,11 +448,26 @@ const fakeSocket = {
   disconnect: vi.fn((callback?: () => void) => callback?.()),
 };
 
-function mockReceive(event: string, response: object) {
+function mockJoinReceive(event: string, response: object) {
   fakeChannel.receive.mockImplementation((e, callback) => {
     if (e === event) {
       callback(response);
     }
     return fakeChannel;
+  });
+}
+
+function mockPushReceive(event: string, response: object) {
+  const mockReceiveChain = {
+    receive: vi.fn().mockImplementation((type, callback) => {
+      if (type === event) {
+        callback(response);
+      }
+      return mockReceiveChain;
+    }),
+  };
+
+  fakeChannel.push.mockImplementationOnce((_event) => {
+    return mockReceiveChain;
   });
 }

--- a/test/channels/session.test.ts
+++ b/test/channels/session.test.ts
@@ -1,6 +1,6 @@
 import * as phoenix from 'phoenix';
 import { randomUUID, randomInt } from 'crypto';
-import { TVLabsChannel } from '../src/channel.js';
+import { SessionChannel } from '../../src/channels/session.js';
 import { SevereServiceError } from 'webdriverio';
 
 const fakeEndpoint = 'ws://localhost:12345';
@@ -18,23 +18,23 @@ beforeEach(() => {
   mockReceive('ok', {});
 });
 
-describe('TV Labs Channel', () => {
+describe('Session Channel', () => {
   it('should be a function', () => {
-    expect(TVLabsChannel).toBeInstanceOf(Function);
+    expect(SessionChannel).toBeInstanceOf(Function);
   });
 
   it('can be instantiated', () => {
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
     );
 
-    expect(channel).toBeInstanceOf(TVLabsChannel);
+    expect(channel).toBeInstanceOf(SessionChannel);
   });
 
   it('calls connect and join on connect', async () => {
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
@@ -60,7 +60,7 @@ describe('TV Labs Channel', () => {
     const requestId = randomUUID();
     const sessionId = randomUUID();
 
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
@@ -110,7 +110,7 @@ describe('TV Labs Channel', () => {
   });
 
   it('raises on failed lobby topic join', async () => {
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
@@ -122,7 +122,7 @@ describe('TV Labs Channel', () => {
   });
 
   it('raises on topic join timeout', async () => {
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
@@ -141,7 +141,7 @@ describe('TV Labs Channel', () => {
       'tvlabs:build': '6277d0d7-71de-4f72-9427-aaaf831e0122',
     };
 
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
@@ -159,7 +159,7 @@ describe('TV Labs Channel', () => {
   it('retries on failure to get request id', async () => {
     const retries = randomInt(2, 10);
 
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
@@ -189,7 +189,7 @@ describe('TV Labs Channel', () => {
     const requestId = randomUUID();
     const retries = randomInt(2, 10);
 
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
@@ -226,7 +226,7 @@ describe('TV Labs Channel', () => {
     const sessionId = randomUUID();
     const retries = randomInt(2, 10);
 
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,
@@ -274,7 +274,7 @@ describe('TV Labs Channel', () => {
     const requestId = randomUUID();
     const retries = randomInt(2, 10);
 
-    const channel = new TVLabsChannel(
+    const channel = new SessionChannel(
       fakeEndpoint,
       reconnectRetries,
       fakeApiKey,

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,13 +1,13 @@
 import { randomInt, randomUUID } from 'crypto';
 import { SevereServiceError } from 'webdriverio';
 import TVLabsService, { type TVLabsCapabilities } from '../src/index.js';
-import { TVLabsChannel } from '../src/channel.js';
+import { SessionChannel } from '../src/channels/session.js';
 
 import type { Options } from '@wdio/types';
 
-vi.mock('../src/channel', () => {
+vi.mock('../src/channels/session', () => {
   return {
-    TVLabsChannel: vi.fn().mockImplementation(() => fakeTVLabsChannel),
+    SessionChannel: vi.fn().mockImplementation(() => fakeSessionChannel),
   };
 });
 
@@ -162,14 +162,14 @@ describe('TVLabsService', () => {
         'tvlabs:build': '6277d0d7-71de-4f72-9427-aaaf831e0122',
       };
 
-      fakeTVLabsChannel.newSession.mockResolvedValue(sessionId);
+      fakeSessionChannel.newSession.mockResolvedValue(sessionId);
 
       const service = new TVLabsService(options, capabilities, config);
 
       await service.beforeSession(config, capabilities, specs, cid);
 
-      expect(fakeTVLabsChannel.connect).toHaveBeenCalled();
-      expect(fakeTVLabsChannel.newSession).toHaveBeenCalledWith(
+      expect(fakeSessionChannel.connect).toHaveBeenCalled();
+      expect(fakeSessionChannel.newSession).toHaveBeenCalledWith(
         capabilities,
         expect.any(Number),
       );
@@ -192,13 +192,13 @@ describe('TVLabsService', () => {
 
       await service.beforeSession(config, capabilities, specs, cid);
 
-      expect(vi.mocked(TVLabsChannel)).toHaveBeenCalledWith(
+      expect(vi.mocked(SessionChannel)).toHaveBeenCalledWith(
         options.endpoint,
         options.reconnectRetries,
         options.apiKey,
         config.logLevel,
       );
-      expect(fakeTVLabsChannel.newSession).toHaveBeenCalledWith(
+      expect(fakeSessionChannel.newSession).toHaveBeenCalledWith(
         capabilities,
         options.retries,
       );
@@ -211,7 +211,7 @@ describe('TVLabsService', () => {
       const options = { apiKey: 'my-api-key' };
       const capabilities: TVLabsCapabilities = {};
 
-      fakeTVLabsChannel.newSession.mockRejectedValue(
+      fakeSessionChannel.newSession.mockRejectedValue(
         new SevereServiceError('Could not create a new session.'),
       );
 
@@ -224,7 +224,7 @@ describe('TVLabsService', () => {
   });
 });
 
-const fakeTVLabsChannel = {
+const fakeSessionChannel = {
   connect: vi.fn(),
   disconnect: vi.fn(),
   newSession: vi.fn(),


### PR DESCRIPTION
- Support build upload through configuration
- Add `BaseChannel` class for connecting to phoenix channels
- Move existing channel logic into `SessionChannel`
- Create new `BuildChannel`

Example:

```
  services: [
    [
      TVLabsService,
      {
        apiKey: process.env.TVLABS_API_TOKEN,
        buildPath: '/Users/tvlabs/Desktop/apps/roku.zip',
        app: "foobar"
      },
    ],
  ],
```