### PR TITLE
feat: add TVLabsService.fromSession() for attaching to existing sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ The factory:
 
 > **Important:** `wdOpts` must be the same reference later passed to `attach()`.
 
-> **Note:** Calling `beforeSession()` on a rehydrated service throws a `SevereServiceError` to prevent accidentally creating a duplicate session.
+> **Note:** Calling `beforeSession()` on a service created via `fromSession()` throws a `SevereServiceError` to prevent accidentally creating a duplicate session.
 
 #### Example
 
@@ -349,7 +349,7 @@ try {
   const metadata = await service.requestMetadata(appiumSessionId, requestId);
   console.log('Request metadata:', metadata);
 } finally {
-  // The consumer typically should NOT delete a session it did not create.
+  // Only delete the session if this process owns its lifecycle.
 }
 ```
 
@@ -371,13 +371,13 @@ const service = await TVLabsService.fromSession(
 - **Returns:** `string | undefined`
 - **Description:** Returns the Appium session ID bound via `fromSession()`, or `undefined` for service instances created through the standard constructor.
 
-## Cross-Repo Session Reuse
+## Attaching to an Existing Session
 
-In a distributed test setup where session creation and session usage happen in different repos, you can use `fromSession()` to reconstruct service context in the consumer repo.
+WebdriverIO's [`attach()`](https://webdriver.io/docs/api/modules#attachoptions) binds a driver to a session that was created earlier — possibly by a different process. Use `TVLabsService.fromSession()` alongside `attach()` to keep TV Labs telemetry (`lastRequestId()`, `requestMetadata()`, `sessionMetadata()`) working for the attaching driver, without recreating the session.
 
-The portable join key is the **Appium session ID** -- the value of `driver.sessionId` after the original `remote()` call. Both `requestMetadata()` and `sessionMetadata()` accept this ID, and `attach()` uses it to bind to the existing session.
+The portable handle is the **Appium session ID** — the value of `driver.sessionId` after the original `remote()` call. Pass it through whatever channel fits your setup (env var, fixture, queue message, file). Both `requestMetadata()` and `sessionMetadata()` accept this ID, and `attach()` uses it to bind to the existing session.
 
-### Session Creator (Repo A)
+### Creating the session
 
 ```javascript
 import { remote } from 'webdriverio';
@@ -399,11 +399,11 @@ const service = new TVLabsService(
 await service.beforeSession(wdOpts, capabilities, [], '');
 const driver = await remote(wdOpts);
 
-// Hand off the Appium session ID to the consumer repo
+// Hand off driver.sessionId to wherever the next driver will attach
 const appiumSessionId = driver.sessionId;
 ```
 
-### Session Consumer (Repo B)
+### Attaching to the session
 
 ```javascript
 import { attach } from 'webdriverio';
@@ -415,7 +415,7 @@ const wdOpts = {
   port: 4723,
 };
 
-// appiumSessionId received from Repo A
+// appiumSessionId received from the process that called remote()
 const service = TVLabsService.fromSession(
   appiumSessionId,
   { apiKey: process.env.TVLABS_API_KEY },
@@ -437,8 +437,8 @@ try {
   const metadata = await service.requestMetadata(appiumSessionId, requestId);
   const session = await service.sessionMetadata(appiumSessionId);
 } finally {
-  // Don't deleteSession unless this consumer owns the session lifecycle.
+  // Only delete the session if this process owns its lifecycle.
 }
 ```
 
-> **Note:** `lastRequestId()` is per-instance -- each repo tracks its own request IDs. The cross-repo join key is the Appium session ID. Use `requestMetadata()` and `sessionMetadata()` for cross-repo telemetry queries.
+> **Note:** `lastRequestId()` is per-instance — each `TVLabsService` tracks the request IDs that flow through its own `transformRequest` hook. Use `requestMetadata()` and `sessionMetadata()` (both keyed by Appium session ID) for telemetry that needs to span instances.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ run();
 - **Default:** `false`
 - **Description:** Whether to continue the session request if any step fails. When `true`, the session request will still be made with the original provided capabilities. When `false`, the service will exit with a non-zero code.
 
+### `validate`
+
+- **Type:** `boolean`
+- **Required:** No
+- **Default:** `false`
+- **Description:** Only used with `TVLabsService.fromSession()`. When `true`, the factory eagerly verifies the session exists by calling the TV Labs API before returning the service instance. This makes `fromSession()` return a `Promise<TVLabsService>` instead of a synchronous `TVLabsService`. If the session is not found, a `SevereServiceError` is thrown.
+
 ## Methods
 
 ### `lastRequestId()`
@@ -279,3 +286,141 @@ try {
   await driver.deleteSession();
 }
 ```
+
+### `TVLabsService.fromSession()`
+
+- **Parameters:** `sessionId: string, options: TVLabsServiceOptions, wdOpts: Options.WebdriverIO`
+- **Returns:** `TVLabsService` (or `Promise<TVLabsService>` when `validate: true`)
+- **Description:** Creates a `TVLabsService` instance bound to an existing session without calling `beforeSession()`. Use this in a consumer repo that receives a `sessionId` from a session creator.
+
+The factory:
+- Sets `tvlabs:session_id` on `wdOpts.capabilities` so `remote(wdOpts)` attaches to the existing session.
+- Injects the `Authorization` header on `wdOpts`.
+- Installs the `x-request-id` tracking hook on `wdOpts` (unless `attachRequestId: false`), so `lastRequestId()` works locally.
+
+> **Important:** `wdOpts` must be the same reference later passed to `remote()`.
+
+> **Note:** Calling `beforeSession()` on a rehydrated service throws a `SevereServiceError` to prevent accidentally creating a duplicate session.
+
+#### Example
+
+```javascript
+import { remote } from 'webdriverio';
+import { TVLabsService } from '@tvlabs/wdio-service';
+
+const capabilities = { ... };
+const wdOpts = {
+  capabilities,
+  hostname: 'appium.tvlabs.ai',
+  port: 4723,
+};
+
+// sessionId is received from the session creator (e.g. Repo A)
+const sessionId = process.env.SESSION_ID;
+
+const service = TVLabsService.fromSession(
+  sessionId,
+  { apiKey: process.env.TVLABS_API_KEY },
+  wdOpts
+);
+
+const driver = await remote(wdOpts);
+
+try {
+  const element = await driver.$('#my-button');
+  await element.click();
+
+  // Request tracking works locally
+  const requestId = service.lastRequestId();
+
+  // Telemetry queries work without beforeSession()
+  const metadata = await service.requestMetadata(sessionId, requestId);
+  console.log('Request metadata:', metadata);
+} finally {
+  await driver.deleteSession();
+}
+```
+
+#### Validated Example
+
+```javascript
+// With validate: true, fromSession returns a Promise and verifies
+// the session exists before returning the service instance.
+const service = await TVLabsService.fromSession(
+  sessionId,
+  { apiKey: process.env.TVLABS_API_KEY, validate: true },
+  wdOpts
+);
+```
+
+### `sessionId`
+
+- **Type:** getter
+- **Returns:** `string | undefined`
+- **Description:** Returns the session ID bound via `fromSession()`, or `undefined` for service instances created through the standard constructor.
+
+## Cross-Repo Session Reuse
+
+In a distributed test setup where session creation and session usage happen in different repos, you can use `fromSession()` to reconstruct service context in the consumer repo.
+
+### Session Creator (Repo A)
+
+```javascript
+import { remote } from 'webdriverio';
+import { TVLabsService } from '@tvlabs/wdio-service';
+
+const capabilities = { ... };
+const wdOpts = {
+  capabilities,
+  hostname: 'appium.tvlabs.ai',
+  port: 4723,
+};
+
+const service = new TVLabsService(
+  { apiKey: process.env.TVLABS_API_KEY },
+  capabilities,
+  wdOpts
+);
+
+await service.beforeSession(wdOpts, capabilities, [], '');
+
+// Pass the session ID to the consumer repo
+const sessionId = capabilities['tvlabs:session_id'];
+```
+
+### Session Consumer (Repo B)
+
+```javascript
+import { remote } from 'webdriverio';
+import { TVLabsService } from '@tvlabs/wdio-service';
+
+const capabilities = { ... };
+const wdOpts = {
+  capabilities,
+  hostname: 'appium.tvlabs.ai',
+  port: 4723,
+};
+
+// sessionId received from Repo A
+const service = TVLabsService.fromSession(
+  sessionId,
+  { apiKey: process.env.TVLABS_API_KEY },
+  wdOpts
+);
+
+const driver = await remote(wdOpts);
+
+try {
+  // All telemetry methods work
+  const element = await driver.$('#my-button');
+  await element.click();
+
+  const requestId = service.lastRequestId();
+  const metadata = await service.requestMetadata(sessionId, requestId);
+  const session = await service.sessionMetadata(sessionId);
+} finally {
+  await driver.deleteSession();
+}
+```
+
+> **Note:** `lastRequestId()` is per-instance -- each repo tracks its own request IDs. The cross-repo join key is `sessionId`. Use `requestMetadata()` and `sessionMetadata()` for cross-repo telemetry queries.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ run();
 - **Type:** `boolean`
 - **Required:** No
 - **Default:** `false`
-- **Description:** Only used with `TVLabsService.fromSession()`. When `true`, the factory eagerly verifies the session exists by calling the TV Labs API before returning the service instance. This makes `fromSession()` return a `Promise<TVLabsService>` instead of a synchronous `TVLabsService`. If the session is not found, a `SevereServiceError` is thrown.
+- **Description:** Only used with `TVLabsService.fromSession()`. When `true`, the factory eagerly verifies the Appium session exists by calling the TV Labs API before returning the service instance. This makes `fromSession()` return a `Promise<TVLabsService>` instead of a synchronous `TVLabsService`. If the session is not found, a `SevereServiceError` is thrown.
 
 ## Methods
 
@@ -240,6 +240,11 @@ const multiMetadata = await service.requestMetadata("appium-session-id-1234"[
 console.log('Multiple requests metadata:', multiMetadata);
 ```
 
+### `disconnect()`
+
+- **Returns:** `Promise<void>`
+- **Description:** Closes any long-lived connections held by the service (currently the metadata channel WebSocket opened by `requestMetadata()`). Call this when you are finished with the service so the process can exit. Safe to call when no channel was opened, and safe to call multiple times.
+
 ### `sessionMetadata()`
 
 - **Parameters:** `appiumSessionId: string`
@@ -247,6 +252,8 @@ console.log('Multiple requests metadata:', multiMetadata);
 - **Description:** Fetches metadata for a session by Appium session ID from the TV Labs platform.
 
 > **Note:** Partial metadata will be available immediately after session creation. Some session metadata such as recording end time, session end time, and session duration are added asynchronously on the TV Labs platform after the session ends. Before the session ends, these fields will be null.
+
+> **Tip:** The response includes both IDs — `data.id` is the TV Labs session ID (useful for deep-linking into `https://tvlabs.ai/app/sessions/:id`) and `data.appium.session_id` is the Appium session ID. Consumers that only have the Appium session ID can resolve the TV Labs session ID from this response.
 
 #### Example
 
@@ -289,43 +296,43 @@ try {
 
 ### `TVLabsService.fromSession()`
 
-- **Parameters:** `sessionId: string, options: TVLabsServiceOptions, wdOpts: Options.WebdriverIO`
+- **Parameters:** `appiumSessionId: string, options: TVLabsServiceOptions, wdOpts: Options.WebdriverIO`
 - **Returns:** `TVLabsService` (or `Promise<TVLabsService>` when `validate: true`)
-- **Description:** Creates a `TVLabsService` instance bound to an existing session without calling `beforeSession()`. Use this in a consumer repo that receives a `sessionId` from a session creator.
+- **Description:** Creates a `TVLabsService` instance bound to an existing Appium session without calling `beforeSession()`. Use this when you have an Appium session ID (the value of `driver.sessionId` after a previous `remote()` call) and want to attach to that session via WebdriverIO's `attach()`.
 
 The factory:
 
-- Sets `tvlabs:session_id` on `wdOpts.capabilities` so `remote(wdOpts)` attaches to the existing session.
 - Injects the `Authorization` header on `wdOpts`.
 - Installs the `x-request-id` tracking hook on `wdOpts` (unless `attachRequestId: false`), so `lastRequestId()` works locally.
+- Records the Appium session ID for use by `appiumSessionId`, `requestMetadata()`, and `sessionMetadata()`.
 
-> **Important:** `wdOpts` must be the same reference later passed to `remote()`.
+> **Important:** `wdOpts` must be the same reference later passed to `attach()`.
 
 > **Note:** Calling `beforeSession()` on a rehydrated service throws a `SevereServiceError` to prevent accidentally creating a duplicate session.
 
 #### Example
 
 ```javascript
-import { remote } from 'webdriverio';
+import { attach } from 'webdriverio';
 import { TVLabsService } from '@tvlabs/wdio-service';
 
-const capabilities = { ... };
 const wdOpts = {
-  capabilities,
+  capabilities: {},
   hostname: 'appium.tvlabs.ai',
   port: 4723,
 };
 
-// sessionId is received from the session creator (e.g. Repo A)
-const sessionId = process.env.SESSION_ID;
+// appiumSessionId is the value of driver.sessionId from the original remote()
+// call, handed off via env var, queue message, etc.
+const appiumSessionId = process.env.APPIUM_SESSION_ID;
 
 const service = TVLabsService.fromSession(
-  sessionId,
+  appiumSessionId,
   { apiKey: process.env.TVLABS_API_KEY },
   wdOpts
 );
 
-const driver = await remote(wdOpts);
+const driver = await attach({ sessionId: appiumSessionId, ...wdOpts, options: wdOpts });
 
 try {
   const element = await driver.$('#my-button');
@@ -335,10 +342,10 @@ try {
   const requestId = service.lastRequestId();
 
   // Telemetry queries work without beforeSession()
-  const metadata = await service.requestMetadata(sessionId, requestId);
+  const metadata = await service.requestMetadata(appiumSessionId, requestId);
   console.log('Request metadata:', metadata);
 } finally {
-  await driver.deleteSession();
+  // The consumer typically should NOT delete a session it did not create.
 }
 ```
 
@@ -348,21 +355,23 @@ try {
 // With validate: true, fromSession returns a Promise and verifies
 // the session exists before returning the service instance.
 const service = await TVLabsService.fromSession(
-  sessionId,
+  appiumSessionId,
   { apiKey: process.env.TVLABS_API_KEY, validate: true },
   wdOpts,
 );
 ```
 
-### `sessionId`
+### `appiumSessionId`
 
 - **Type:** getter
 - **Returns:** `string | undefined`
-- **Description:** Returns the session ID bound via `fromSession()`, or `undefined` for service instances created through the standard constructor.
+- **Description:** Returns the Appium session ID bound via `fromSession()`, or `undefined` for service instances created through the standard constructor.
 
 ## Cross-Repo Session Reuse
 
 In a distributed test setup where session creation and session usage happen in different repos, you can use `fromSession()` to reconstruct service context in the consumer repo.
+
+The portable join key is the **Appium session ID** -- the value of `driver.sessionId` after the original `remote()` call. Both `requestMetadata()` and `sessionMetadata()` accept this ID, and `attach()` uses it to bind to the existing session.
 
 ### Session Creator (Repo A)
 
@@ -384,32 +393,32 @@ const service = new TVLabsService(
 );
 
 await service.beforeSession(wdOpts, capabilities, [], '');
+const driver = await remote(wdOpts);
 
-// Pass the session ID to the consumer repo
-const sessionId = capabilities['tvlabs:session_id'];
+// Hand off the Appium session ID to the consumer repo
+const appiumSessionId = driver.sessionId;
 ```
 
 ### Session Consumer (Repo B)
 
 ```javascript
-import { remote } from 'webdriverio';
+import { attach } from 'webdriverio';
 import { TVLabsService } from '@tvlabs/wdio-service';
 
-const capabilities = { ... };
 const wdOpts = {
-  capabilities,
+  capabilities: {},
   hostname: 'appium.tvlabs.ai',
   port: 4723,
 };
 
-// sessionId received from Repo A
+// appiumSessionId received from Repo A
 const service = TVLabsService.fromSession(
-  sessionId,
+  appiumSessionId,
   { apiKey: process.env.TVLABS_API_KEY },
   wdOpts
 );
 
-const driver = await remote(wdOpts);
+const driver = await attach({ sessionId: appiumSessionId, ...wdOpts, options: wdOpts });
 
 try {
   // All telemetry methods work
@@ -417,11 +426,11 @@ try {
   await element.click();
 
   const requestId = service.lastRequestId();
-  const metadata = await service.requestMetadata(sessionId, requestId);
-  const session = await service.sessionMetadata(sessionId);
+  const metadata = await service.requestMetadata(appiumSessionId, requestId);
+  const session = await service.sessionMetadata(appiumSessionId);
 } finally {
-  await driver.deleteSession();
+  // Don't deleteSession unless this consumer owns the session lifecycle.
 }
 ```
 
-> **Note:** `lastRequestId()` is per-instance -- each repo tracks its own request IDs. The cross-repo join key is `sessionId`. Use `requestMetadata()` and `sessionMetadata()` for cross-repo telemetry queries.
+> **Note:** `lastRequestId()` is per-instance -- each repo tracks its own request IDs. The cross-repo join key is the Appium session ID. Use `requestMetadata()` and `sessionMetadata()` for cross-repo telemetry queries.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ export const config = {
 };
 ```
 
-### WebdriverIO Remote
+### Standalone (remote)
 
-To use this with WebdriverIO remote but without the test runner, call the beforeSession hook before instantiating the remote.
+To use this with WebdriverIO remote but without the test runner, call `beforeSession()` before instantiating the remote.
 
 ```javascript
 import { remote } from 'webdriverio';
@@ -71,20 +71,14 @@ async function run() {
     port: 4723
   };
 
-  const serviceOpts = {
-    apiKey: process.env.TVLABS_API_TOKEN,
-  }
+  // NOTE: wdOpts must be the same reference passed to remote()
+  const service = new TVLabsService(
+    { apiKey: process.env.TVLABS_API_KEY },
+    capabilities,
+    wdOpts,
+  );
 
-  // NOTE: it is important to make sure that
-  // the wdOpts passed here are the same reference
-  // as the one passed to remote()
-  const service = new TVLabsService(serviceOpts, capabilities, wdOpts)
-
-  // The TV Labs service does not use specs or a cid, pass default values.
-  const cid = ""
-  const specs = []
-
-  await service.beforeSession(wdOpts, capabilities, specs, cid)
+  await service.beforeSession(wdOpts, capabilities, [], '');
 
   const driver = await remote(wdOpts);
 
@@ -97,6 +91,78 @@ async function run() {
 
 run();
 ```
+
+### Attaching to an Existing Session
+
+WebdriverIO's [`attach()`](https://webdriver.io/docs/api/modules#attachoptions) binds a driver to a session that was created earlier — possibly by a different process. Use `TVLabsService.fromSession()` alongside `attach()` to keep TV Labs telemetry (`lastRequestId()`, `requestMetadata()`, `sessionMetadata()`) working for the attaching driver, without recreating the session.
+
+The portable handle is the **Appium session ID** — the value of `driver.sessionId` after the original `remote()` call. Pass it through whatever channel fits your setup (env var, fixture, queue message, file).
+
+#### Creating the session
+
+```javascript
+import { remote } from 'webdriverio';
+import { TVLabsService } from '@tvlabs/wdio-service';
+
+const capabilities = { ... };
+const wdOpts = {
+  capabilities,
+  hostname: 'appium.tvlabs.ai',
+  port: 4723,
+};
+
+const service = new TVLabsService(
+  { apiKey: process.env.TVLABS_API_KEY },
+  capabilities,
+  wdOpts,
+);
+
+await service.beforeSession(wdOpts, capabilities, [], '');
+const driver = await remote(wdOpts);
+
+// Hand off driver.sessionId to wherever the attaching process will pick it up
+const appiumSessionId = driver.sessionId;
+```
+
+#### Attaching to the session
+
+```javascript
+import { attach } from 'webdriverio';
+import { TVLabsService } from '@tvlabs/wdio-service';
+
+const wdOpts = {
+  capabilities: {},
+  hostname: 'appium.tvlabs.ai',
+  port: 4723,
+};
+
+// appiumSessionId received from the session-creating process
+const service = TVLabsService.fromSession(
+  appiumSessionId,
+  { apiKey: process.env.TVLABS_API_KEY },
+  wdOpts,
+);
+
+const driver = await attach({
+  sessionId: appiumSessionId,
+  ...wdOpts,
+  options: wdOpts,
+});
+
+try {
+  const element = await driver.$('#my-button');
+  await element.click();
+
+  const requestId = service.lastRequestId();
+  const metadata = await service.requestMetadata(appiumSessionId, requestId);
+  const session = await service.sessionMetadata(appiumSessionId);
+} finally {
+  await service.disconnect();
+  // Only delete the session if this process owns its lifecycle.
+}
+```
+
+> **Note:** `lastRequestId()` is per-instance — each `TVLabsService` tracks request IDs that flow through its own `transformRequest` hook. Use `requestMetadata()` and `sessionMetadata()` (both keyed by Appium session ID) for telemetry that needs to span instances.
 
 ## Options
 
@@ -151,39 +217,15 @@ run();
 ### `lastRequestId()`
 
 - **Returns:** `string | undefined`
-- **Description:** Returns the last request ID that was attached to a request made to the TV Labs platform. This is useful for correlating client-side logs with server-side logs. Returns `undefined` if no request has been made yet or if `attachRequestId` is set to `false`.
-
-#### Example
-
-```javascript
-import { remote } from 'webdriverio';
-import { TVLabsService } from '@tvlabs/wdio-service';
-
-const capabilities = { ... };
-const wdOpts = { ... };
-
-const service = new TVLabsService(
-  { apiKey: process.env.TVLABS_API_KEY },
-  capabilities,
-  wdOpts
-);
-
-await service.beforeSession(wdOpts, capabilities, [], '');
-
-const driver = await remote(wdOpts);
-
-// Get the last request ID
-const requestId = service.lastRequestId();
-console.log(`Last request ID: ${requestId}`);
-```
+- **Description:** Returns the last request ID attached to a request made to the TV Labs platform. Useful for correlating client-side logs with server-side logs. Returns `undefined` if no request has been made yet or if `attachRequestId` is `false`.
 
 ### `requestMetadata()`
 
 - **Parameters:** `appiumSessionId: string, requestIds: string | string[]`
 - **Returns:** `Promise<TVLabsRequestMetadata | TVLabsRequestMetadataResponse>`
-- **Description:** Fetches metadata for one or more Appium request IDs from the TV Labs platform. If a single request ID is provided, returns the metadata for that request. If an array of request IDs is provided, returns a map where keys are request IDs and values are their corresponding metadata.
+- **Description:** Fetches metadata for one or more request IDs from the TV Labs platform. Pass a single request ID to get its metadata directly; pass an array to get a map keyed by request ID.
 
-> **Note:** Request metadata is processed asynchronously on the TV Labs platform. To ensure metadata is available, it is recommended to fetch request metadata a few seconds after the request, or after the session has ended.
+> **Note:** Request metadata is processed asynchronously on the TV Labs platform. Fetch after the session ends, or wait a few seconds after the request, to ensure the data is available.
 
 #### Example
 
@@ -197,7 +239,7 @@ const wdOpts = { ... };
 const service = new TVLabsService(
   { apiKey: process.env.TVLABS_API_KEY },
   capabilities,
-  wdOpts
+  wdOpts,
 );
 
 await service.beforeSession(wdOpts, capabilities, [], '');
@@ -206,39 +248,27 @@ const driver = await remote(wdOpts);
 let requestId;
 
 try {
-  // Perform some actions that generate requests
   const element = await driver.$('#my-button');
   await element.click();
-
-  // Get the request ID from the click
   requestId = service.lastRequestId();
-  console.log(`Request ID: ${requestId}`);
 } finally {
   await driver.deleteSession();
 }
 
-// Fetch metadata after session ends (recommended)
+// Single request
 if (requestId) {
   const metadata = await service.requestMetadata(driver.sessionId, requestId);
   console.log('Request metadata:', metadata);
 }
 
-// Fetch metadata for multiple requests
-const multiMetadata = await service.requestMetadata("appium-session-id-1234"[
+// Multiple requests
+const multiMetadata = await service.requestMetadata(driver.sessionId, [
   'request-id-123',
   'request-id-456',
-  'request-id-789'
+  'request-id-789',
 ]);
-
 console.log('Multiple requests metadata:', multiMetadata);
 ```
-
-### `disconnect()`
-
-- **Returns:** `Promise<void>`
-- **Description:** Closes any long-lived connections held by the service (currently the metadata channel WebSocket opened by `requestMetadata()`). Call this when you are finished with the service so the process can exit. Safe to call when no channel was opened, and safe to call multiple times.
-
-> **Note:** Await all in-flight `requestMetadata()` calls before calling `disconnect()`. Tearing down the metadata channel while a request is pending will cause that call to reject.
 
 ### `sessionMetadata()`
 
@@ -246,7 +276,7 @@ console.log('Multiple requests metadata:', multiMetadata);
 - **Returns:** `Promise<TVLabsSessionMetadataResponse>`
 - **Description:** Fetches metadata for a session by Appium session ID from the TV Labs platform.
 
-> **Note:** Partial metadata will be available immediately after session creation. Some session metadata such as recording end time, session end time, and session duration are added asynchronously on the TV Labs platform after the session ends. Before the session ends, these fields will be null.
+> **Note:** Partial metadata will be available immediately after session creation. Fields such as recording end time, session end time, and session duration are populated asynchronously after the session ends — they will be `null` until then.
 
 > **Tip:** The response includes both IDs — `data.id` is the TV Labs session ID (useful for deep-linking into `https://tvlabs.ai/app/sessions/:id`) and `data.appium.session_id` is the Appium session ID. Consumers that only have the Appium session ID can resolve the TV Labs session ID from this response.
 
@@ -262,7 +292,7 @@ const wdOpts = { ... };
 const service = new TVLabsService(
   { apiKey: process.env.TVLABS_API_KEY },
   capabilities,
-  wdOpts
+  wdOpts,
 );
 
 await service.beforeSession(wdOpts, capabilities, [], '');
@@ -271,23 +301,32 @@ const driver = await remote(wdOpts);
 const { sessionId } = driver;
 
 try {
-  const sessionMetadata = await service.sessionMetadata(sessionId);
-
-  const { data:
-    {
-      device: {
-        make: { display_name: make },
-        model: { display_name: model, year }
-      },
-      recording: { start_time }
-    }
-  } = sessionMetadata;
-
-  console.log(`Recording on ${year} ${make} ${model} started at ${start_time}`);
+  // ...
 } finally {
   await driver.deleteSession();
 }
+
+const sessionMetadata = await service.sessionMetadata(sessionId);
+
+const { data: {
+  device: {
+    make: { display_name: make },
+    model: { display_name: model, year },
+  },
+  recording: { start_time },
+} } = sessionMetadata;
+
+console.log(`Recording on ${year} ${make} ${model} started at ${start_time}`);
 ```
+
+### `disconnect()`
+
+- **Returns:** `Promise<void>`
+- **Description:** Closes any long-lived connections held by the service (currently the metadata channel WebSocket opened by `requestMetadata()`). Call this when you are finished with the service so the process can exit. Safe to call when no channel was opened, and safe to call multiple times.
+
+> **Note:** Await all in-flight `requestMetadata()` calls before calling `disconnect()`. Tearing down the metadata channel while a request is pending will cause that call to reject.
+
+## Static Factory
 
 ### `TVLabsService.fromSession()`
 
@@ -298,132 +337,17 @@ try {
 The factory:
 
 - Injects the `Authorization` header on `wdOpts`.
-- Installs the `x-request-id` tracking hook on `wdOpts` (unless `attachRequestId: false`), so `lastRequestId()` works locally.
+- Installs the `x-request-id` tracking hook on `wdOpts` (unless `attachRequestId: false`), so `lastRequestId()` works on the attached driver.
 - Records the Appium session ID for use by `appiumSessionId`, `requestMetadata()`, and `sessionMetadata()`.
 
 > **Important:** `wdOpts` must be the same reference later passed to `attach()`.
 
 > **Note:** Calling `beforeSession()` on a service created via `fromSession()` throws a `SevereServiceError` to prevent accidentally creating a duplicate session.
 
-> **Tip:** To verify the session exists before using it, call `await service.sessionMetadata(appiumSessionId)` immediately after construction. It throws a `SevereServiceError` if the session is not found or the API key cannot access it.
-
-#### Example
-
-```javascript
-import { attach } from 'webdriverio';
-import { TVLabsService } from '@tvlabs/wdio-service';
-
-const wdOpts = {
-  capabilities: {},
-  hostname: 'appium.tvlabs.ai',
-  port: 4723,
-};
-
-// appiumSessionId is the value of driver.sessionId from the original remote()
-// call, handed off via env var, queue message, etc.
-const appiumSessionId = process.env.APPIUM_SESSION_ID;
-
-const service = TVLabsService.fromSession(
-  appiumSessionId,
-  { apiKey: process.env.TVLABS_API_KEY },
-  wdOpts,
-);
-
-const driver = await attach({
-  sessionId: appiumSessionId,
-  ...wdOpts,
-  options: wdOpts,
-});
-
-try {
-  const element = await driver.$('#my-button');
-  await element.click();
-
-  // Request tracking works locally
-  const requestId = service.lastRequestId();
-
-  // Telemetry queries work without beforeSession()
-  const metadata = await service.requestMetadata(appiumSessionId, requestId);
-  console.log('Request metadata:', metadata);
-} finally {
-  // Only delete the session if this process owns its lifecycle.
-}
-```
+> **Tip:** To verify the session exists before using it, call `await service.sessionMetadata(appiumSessionId)` immediately after construction. It throws if the session is not found or the API key cannot access it.
 
 ### `appiumSessionId`
 
 - **Type:** getter
 - **Returns:** `string | undefined`
 - **Description:** Returns the Appium session ID bound via `fromSession()`, or `undefined` for service instances created through the standard constructor.
-
-## Attaching to an Existing Session
-
-WebdriverIO's [`attach()`](https://webdriver.io/docs/api/modules#attachoptions) binds a driver to a session that was created earlier — possibly by a different process. Use `TVLabsService.fromSession()` alongside `attach()` to keep TV Labs telemetry (`lastRequestId()`, `requestMetadata()`, `sessionMetadata()`) working for the attaching driver, without recreating the session.
-
-The portable handle is the **Appium session ID** — the value of `driver.sessionId` after the original `remote()` call. Pass it through whatever channel fits your setup (env var, fixture, queue message, file). Both `requestMetadata()` and `sessionMetadata()` accept this ID, and `attach()` uses it to bind to the existing session.
-
-### Creating the session
-
-```javascript
-import { remote } from 'webdriverio';
-import { TVLabsService } from '@tvlabs/wdio-service';
-
-const capabilities = { ... };
-const wdOpts = {
-  capabilities,
-  hostname: 'appium.tvlabs.ai',
-  port: 4723,
-};
-
-const service = new TVLabsService(
-  { apiKey: process.env.TVLABS_API_KEY },
-  capabilities,
-  wdOpts
-);
-
-await service.beforeSession(wdOpts, capabilities, [], '');
-const driver = await remote(wdOpts);
-
-// Hand off driver.sessionId to wherever the next driver will attach
-const appiumSessionId = driver.sessionId;
-```
-
-### Attaching to the session
-
-```javascript
-import { attach } from 'webdriverio';
-import { TVLabsService } from '@tvlabs/wdio-service';
-
-const wdOpts = {
-  capabilities: {},
-  hostname: 'appium.tvlabs.ai',
-  port: 4723,
-};
-
-// appiumSessionId received from the process that called remote()
-const service = TVLabsService.fromSession(
-  appiumSessionId,
-  { apiKey: process.env.TVLABS_API_KEY },
-  wdOpts,
-);
-
-const driver = await attach({
-  sessionId: appiumSessionId,
-  ...wdOpts,
-  options: wdOpts,
-});
-
-try {
-  // All telemetry methods work
-  const element = await driver.$('#my-button');
-  await element.click();
-
-  const requestId = service.lastRequestId();
-  const metadata = await service.requestMetadata(appiumSessionId, requestId);
-  const session = await service.sessionMetadata(appiumSessionId);
-} finally {
-  // Only delete the session if this process owns its lifecycle.
-}
-```
-
-> **Note:** `lastRequestId()` is per-instance — each `TVLabsService` tracks the request IDs that flow through its own `transformRequest` hook. Use `requestMetadata()` and `sessionMetadata()` (both keyed by Appium session ID) for telemetry that needs to span instances.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ try {
 - **Description:** Creates a `TVLabsService` instance bound to an existing session without calling `beforeSession()`. Use this in a consumer repo that receives a `sessionId` from a session creator.
 
 The factory:
+
 - Sets `tvlabs:session_id` on `wdOpts.capabilities` so `remote(wdOpts)` attaches to the existing session.
 - Injects the `Authorization` header on `wdOpts`.
 - Installs the `x-request-id` tracking hook on `wdOpts` (unless `attachRequestId: false`), so `lastRequestId()` works locally.
@@ -349,7 +350,7 @@ try {
 const service = await TVLabsService.fromSession(
   sessionId,
   { apiKey: process.env.TVLABS_API_KEY, validate: true },
-  wdOpts
+  wdOpts,
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -329,10 +329,14 @@ const appiumSessionId = process.env.APPIUM_SESSION_ID;
 const service = TVLabsService.fromSession(
   appiumSessionId,
   { apiKey: process.env.TVLABS_API_KEY },
-  wdOpts
+  wdOpts,
 );
 
-const driver = await attach({ sessionId: appiumSessionId, ...wdOpts, options: wdOpts });
+const driver = await attach({
+  sessionId: appiumSessionId,
+  ...wdOpts,
+  options: wdOpts,
+});
 
 try {
   const element = await driver.$('#my-button');
@@ -415,10 +419,14 @@ const wdOpts = {
 const service = TVLabsService.fromSession(
   appiumSessionId,
   { apiKey: process.env.TVLABS_API_KEY },
-  wdOpts
+  wdOpts,
 );
 
-const driver = await attach({ sessionId: appiumSessionId, ...wdOpts, options: wdOpts });
+const driver = await attach({
+  sessionId: appiumSessionId,
+  ...wdOpts,
+  options: wdOpts,
+});
 
 try {
   // All telemetry methods work

--- a/README.md
+++ b/README.md
@@ -146,13 +146,6 @@ run();
 - **Default:** `false`
 - **Description:** Whether to continue the session request if any step fails. When `true`, the session request will still be made with the original provided capabilities. When `false`, the service will exit with a non-zero code.
 
-### `validate`
-
-- **Type:** `boolean`
-- **Required:** No
-- **Default:** `false`
-- **Description:** Only used with `TVLabsService.fromSession()`. When `true`, the factory eagerly verifies the Appium session exists by calling the TV Labs API before returning the service instance. This makes `fromSession()` return a `Promise<TVLabsService>` instead of a synchronous `TVLabsService`. If the session is not found, a `SevereServiceError` is thrown.
-
 ## Methods
 
 ### `lastRequestId()`
@@ -245,6 +238,8 @@ console.log('Multiple requests metadata:', multiMetadata);
 - **Returns:** `Promise<void>`
 - **Description:** Closes any long-lived connections held by the service (currently the metadata channel WebSocket opened by `requestMetadata()`). Call this when you are finished with the service so the process can exit. Safe to call when no channel was opened, and safe to call multiple times.
 
+> **Note:** Await all in-flight `requestMetadata()` calls before calling `disconnect()`. Tearing down the metadata channel while a request is pending will cause that call to reject.
+
 ### `sessionMetadata()`
 
 - **Parameters:** `appiumSessionId: string`
@@ -297,7 +292,7 @@ try {
 ### `TVLabsService.fromSession()`
 
 - **Parameters:** `appiumSessionId: string, options: TVLabsServiceOptions, wdOpts: Options.WebdriverIO`
-- **Returns:** `TVLabsService` (or `Promise<TVLabsService>` when `validate: true`)
+- **Returns:** `TVLabsService`
 - **Description:** Creates a `TVLabsService` instance bound to an existing Appium session without calling `beforeSession()`. Use this when you have an Appium session ID (the value of `driver.sessionId` after a previous `remote()` call) and want to attach to that session via WebdriverIO's `attach()`.
 
 The factory:
@@ -309,6 +304,8 @@ The factory:
 > **Important:** `wdOpts` must be the same reference later passed to `attach()`.
 
 > **Note:** Calling `beforeSession()` on a service created via `fromSession()` throws a `SevereServiceError` to prevent accidentally creating a duplicate session.
+
+> **Tip:** To verify the session exists before using it, call `await service.sessionMetadata(appiumSessionId)` immediately after construction. It throws a `SevereServiceError` if the session is not found or the API key cannot access it.
 
 #### Example
 
@@ -351,18 +348,6 @@ try {
 } finally {
   // Only delete the session if this process owns its lifecycle.
 }
-```
-
-#### Validated Example
-
-```javascript
-// With validate: true, fromSession returns a Promise and verifies
-// the session exists before returning the service instance.
-const service = await TVLabsService.fromSession(
-  appiumSessionId,
-  { apiKey: process.env.TVLABS_API_KEY, validate: true },
-  wdOpts,
-);
 ```
 
 ### `appiumSessionId`

--- a/src/service.ts
+++ b/src/service.ts
@@ -22,6 +22,8 @@ export default class TVLabsService implements Services.ServiceInstance {
   private log: Logger;
   private requestId: string | undefined;
   private metadataChannel: MetadataChannel | undefined;
+  private _sessionId: string | undefined;
+  private _rehydrated: boolean = false;
 
   constructor(
     private _options: TVLabsServiceOptions,
@@ -37,6 +39,86 @@ export default class TVLabsService implements Services.ServiceInstance {
     }
 
     this.log.info(`Instantiated TVLabsService v${getServiceVersion()}`);
+  }
+
+  /**
+   * Creates a TVLabsService instance bound to an existing session.
+   *
+   * Use this in a consumer repo that receives a `sessionId` from a session
+   * creator. The returned service supports `lastRequestId()`,
+   * `requestMetadata()`, and `sessionMetadata()` without calling
+   * `beforeSession()`.
+   *
+   * **Important:** `wdOpts` must be the same reference later passed to
+   * `remote()`. The factory mutates it to inject the authorization header,
+   * request-id tracking hook, and `tvlabs:session_id` capability.
+   *
+   * @param sessionId - The TV Labs session ID obtained from the session creator.
+   * @param options - Service options. Pass `validate: true` to eagerly verify the session exists.
+   * @param wdOpts - WebdriverIO remote options. Must be the same reference passed to `remote()`.
+   */
+  static fromSession(
+    sessionId: string,
+    options: TVLabsServiceOptions & { validate: true },
+    wdOpts: Options.WebdriverIO & { capabilities?: unknown },
+  ): Promise<TVLabsService>;
+  static fromSession(
+    sessionId: string,
+    options: TVLabsServiceOptions,
+    wdOpts: Options.WebdriverIO & { capabilities?: unknown },
+  ): TVLabsService;
+  static fromSession(
+    sessionId: string,
+    options: TVLabsServiceOptions,
+    wdOpts: Options.WebdriverIO & { capabilities?: unknown },
+  ): TVLabsService | Promise<TVLabsService> {
+    if (
+      !wdOpts.capabilities ||
+      typeof wdOpts.capabilities !== 'object' ||
+      Array.isArray(wdOpts.capabilities)
+    ) {
+      throw new SevereServiceError(
+        'wdOpts.capabilities must be a capabilities object. Multi-remote capabilities are not supported.',
+      );
+    }
+
+    const capabilities = wdOpts.capabilities as TVLabsCapabilities;
+    const service = new TVLabsService(
+      options,
+      capabilities as Capabilities.ResolvedTestrunnerCapabilities,
+      wdOpts as Options.WebdriverIO,
+    );
+
+    service._rehydrated = true;
+    service._sessionId = sessionId;
+    capabilities['tvlabs:session_id'] = sessionId;
+
+    if (options.validate) {
+      return getSessionMetadata(
+        {
+          baseUrl: service.apiBaseUrl(),
+          apiKey: service.apiKey(),
+          logLevel: service.logLevel(),
+        },
+        sessionId,
+      )
+        .then(() => service)
+        .catch((error) => {
+          throw new SevereServiceError(
+            `Cannot rehydrate: session ${sessionId} not found or inaccessible. ${error instanceof Error ? error.message : String(error)}`,
+          );
+        });
+    }
+
+    return service;
+  }
+
+  /**
+   * Returns the session ID bound via `fromSession()`, or `undefined`
+   * for service instances created through the standard constructor.
+   */
+  get sessionId(): string | undefined {
+    return this._sessionId;
   }
 
   lastRequestId(): string | undefined {
@@ -115,6 +197,12 @@ export default class TVLabsService implements Services.ServiceInstance {
     _specs: string[],
     _cid: string,
   ) {
+    if (this._rehydrated) {
+      throw new SevereServiceError(
+        'beforeSession() is not valid on a rehydrated service. The session was supplied to fromSession() and should not be recreated.',
+      );
+    }
+
     try {
       const buildPath = this.buildPath();
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -22,8 +22,7 @@ export default class TVLabsService implements Services.ServiceInstance {
   private log: Logger;
   private requestId: string | undefined;
   private metadataChannel: MetadataChannel | undefined;
-  private _appiumSessionId: string | undefined;
-  private _rehydrated: boolean = false;
+  private _rehydratedSessionId: string | undefined;
 
   constructor(
     private _options: TVLabsServiceOptions,
@@ -85,11 +84,7 @@ export default class TVLabsService implements Services.ServiceInstance {
       wdOpts as Options.WebdriverIO,
     );
 
-    // _rehydrated and _appiumSessionId are always set together by this factory.
-    // Do not set either independently — the beforeSession() guard and the
-    // appiumSessionId getter both rely on them being in sync.
-    service._rehydrated = true;
-    service._appiumSessionId = appiumSessionId;
+    service._rehydratedSessionId = appiumSessionId;
 
     return service;
   }
@@ -98,8 +93,8 @@ export default class TVLabsService implements Services.ServiceInstance {
    * Returns the Appium session ID bound via `fromSession()`, or `undefined`
    * for service instances created through the standard constructor.
    */
-  get appiumSessionId(): string | undefined {
-    return this._appiumSessionId;
+  get rehydratedSessionId(): string | undefined {
+    return this._rehydratedSessionId;
   }
 
   lastRequestId(): string | undefined {
@@ -194,7 +189,7 @@ export default class TVLabsService implements Services.ServiceInstance {
     _specs: string[],
     _cid: string,
   ) {
-    if (this._rehydrated) {
+    if (this._rehydratedSessionId) {
       throw new SevereServiceError(
         'beforeSession() is not valid on a rehydrated service. The session was supplied to fromSession() and should not be recreated.',
       );

--- a/src/service.ts
+++ b/src/service.ts
@@ -54,25 +54,20 @@ export default class TVLabsService implements Services.ServiceInstance {
    * `attach()`. The factory mutates it to inject the authorization header
    * and the request-id tracking hook.
    *
+   * To verify the session exists before using it, call
+   * `await service.sessionMetadata(appiumSessionId)` immediately after
+   * construction. It throws if the session is not found or the API key
+   * cannot access it.
+   *
    * @param appiumSessionId - The Appium session ID returned by the proxy on the original `POST /session`. This is the value of `driver.sessionId` after `remote()` succeeded.
-   * @param options - Service options. Pass `validate: true` to eagerly verify the session exists.
+   * @param options - Service options.
    * @param wdOpts - WebdriverIO remote options. Must be the same reference passed to `attach()`.
    */
   static fromSession(
     appiumSessionId: string,
-    options: TVLabsServiceOptions & { validate: true },
-    wdOpts: Options.WebdriverIO & { capabilities?: unknown },
-  ): Promise<TVLabsService>;
-  static fromSession(
-    appiumSessionId: string,
     options: TVLabsServiceOptions,
     wdOpts: Options.WebdriverIO & { capabilities?: unknown },
-  ): TVLabsService;
-  static fromSession(
-    appiumSessionId: string,
-    options: TVLabsServiceOptions,
-    wdOpts: Options.WebdriverIO & { capabilities?: unknown },
-  ): TVLabsService | Promise<TVLabsService> {
+  ): TVLabsService {
     if (
       !wdOpts.capabilities ||
       typeof wdOpts.capabilities !== 'object' ||
@@ -90,25 +85,11 @@ export default class TVLabsService implements Services.ServiceInstance {
       wdOpts as Options.WebdriverIO,
     );
 
+    // _rehydrated and _appiumSessionId are always set together by this factory.
+    // Do not set either independently — the beforeSession() guard and the
+    // appiumSessionId getter both rely on them being in sync.
     service._rehydrated = true;
     service._appiumSessionId = appiumSessionId;
-
-    if (options.validate) {
-      return getSessionMetadata(
-        {
-          baseUrl: service.apiBaseUrl(),
-          apiKey: service.apiKey(),
-          logLevel: service.logLevel(),
-        },
-        appiumSessionId,
-      )
-        .then(() => service)
-        .catch((error) => {
-          throw new SevereServiceError(
-            `Cannot rehydrate: session ${appiumSessionId} not found or inaccessible. ${error instanceof Error ? error.message : String(error)}`,
-          );
-        });
-    }
 
     return service;
   }
@@ -176,6 +157,10 @@ export default class TVLabsService implements Services.ServiceInstance {
    * Closes any long-lived connections held by the service (currently the
    * metadata channel WebSocket). Safe to call when no channel was opened.
    * Call this when you are finished with the service so the process can exit.
+   *
+   * **Ordering:** Await all in-flight `requestMetadata()` calls before calling
+   * `disconnect()`. Tearing down the metadata channel while a request is
+   * pending will cause that call to reject.
    */
   async disconnect(): Promise<void> {
     if (this.metadataChannel) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -22,7 +22,7 @@ export default class TVLabsService implements Services.ServiceInstance {
   private log: Logger;
   private requestId: string | undefined;
   private metadataChannel: MetadataChannel | undefined;
-  private _sessionId: string | undefined;
+  private _appiumSessionId: string | undefined;
   private _rehydrated: boolean = false;
 
   constructor(
@@ -42,33 +42,34 @@ export default class TVLabsService implements Services.ServiceInstance {
   }
 
   /**
-   * Creates a TVLabsService instance bound to an existing session.
+   * Creates a TVLabsService instance bound to an existing Appium session.
    *
-   * Use this in a consumer repo that receives a `sessionId` from a session
-   * creator. The returned service supports `lastRequestId()`,
-   * `requestMetadata()`, and `sessionMetadata()` without calling
-   * `beforeSession()`.
+   * Use this when you have an Appium session ID (e.g. from `driver.sessionId`
+   * after a previous `remote()` call, possibly in another process) and want
+   * to attach to it via `attach({ sessionId, ...wdOpts })`. The returned
+   * service supports `lastRequestId()`, `requestMetadata()`, and
+   * `sessionMetadata()` without calling `beforeSession()`.
    *
    * **Important:** `wdOpts` must be the same reference later passed to
-   * `remote()`. The factory mutates it to inject the authorization header,
-   * request-id tracking hook, and `tvlabs:session_id` capability.
+   * `attach()`. The factory mutates it to inject the authorization header
+   * and the request-id tracking hook.
    *
-   * @param sessionId - The TV Labs session ID obtained from the session creator.
+   * @param appiumSessionId - The Appium session ID returned by the proxy on the original `POST /session`. This is the value of `driver.sessionId` after `remote()` succeeded.
    * @param options - Service options. Pass `validate: true` to eagerly verify the session exists.
-   * @param wdOpts - WebdriverIO remote options. Must be the same reference passed to `remote()`.
+   * @param wdOpts - WebdriverIO remote options. Must be the same reference passed to `attach()`.
    */
   static fromSession(
-    sessionId: string,
+    appiumSessionId: string,
     options: TVLabsServiceOptions & { validate: true },
     wdOpts: Options.WebdriverIO & { capabilities?: unknown },
   ): Promise<TVLabsService>;
   static fromSession(
-    sessionId: string,
+    appiumSessionId: string,
     options: TVLabsServiceOptions,
     wdOpts: Options.WebdriverIO & { capabilities?: unknown },
   ): TVLabsService;
   static fromSession(
-    sessionId: string,
+    appiumSessionId: string,
     options: TVLabsServiceOptions,
     wdOpts: Options.WebdriverIO & { capabilities?: unknown },
   ): TVLabsService | Promise<TVLabsService> {
@@ -90,8 +91,7 @@ export default class TVLabsService implements Services.ServiceInstance {
     );
 
     service._rehydrated = true;
-    service._sessionId = sessionId;
-    capabilities['tvlabs:session_id'] = sessionId;
+    service._appiumSessionId = appiumSessionId;
 
     if (options.validate) {
       return getSessionMetadata(
@@ -100,12 +100,12 @@ export default class TVLabsService implements Services.ServiceInstance {
           apiKey: service.apiKey(),
           logLevel: service.logLevel(),
         },
-        sessionId,
+        appiumSessionId,
       )
         .then(() => service)
         .catch((error) => {
           throw new SevereServiceError(
-            `Cannot rehydrate: session ${sessionId} not found or inaccessible. ${error instanceof Error ? error.message : String(error)}`,
+            `Cannot rehydrate: session ${appiumSessionId} not found or inaccessible. ${error instanceof Error ? error.message : String(error)}`,
           );
         });
     }
@@ -114,11 +114,11 @@ export default class TVLabsService implements Services.ServiceInstance {
   }
 
   /**
-   * Returns the session ID bound via `fromSession()`, or `undefined`
+   * Returns the Appium session ID bound via `fromSession()`, or `undefined`
    * for service instances created through the standard constructor.
    */
-  get sessionId(): string | undefined {
-    return this._sessionId;
+  get appiumSessionId(): string | undefined {
+    return this._appiumSessionId;
   }
 
   lastRequestId(): string | undefined {
@@ -170,6 +170,18 @@ export default class TVLabsService implements Services.ServiceInstance {
       },
       sessionId,
     );
+  }
+
+  /**
+   * Closes any long-lived connections held by the service (currently the
+   * metadata channel WebSocket). Safe to call when no channel was opened.
+   * Call this when you are finished with the service so the process can exit.
+   */
+  async disconnect(): Promise<void> {
+    if (this.metadataChannel) {
+      await this.metadataChannel.disconnect();
+      this.metadataChannel = undefined;
+    }
   }
 
   onPrepare(

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ export type TVLabsServiceOptions = {
   reconnectRetries?: number;
   attachRequestId?: boolean;
   continueOnError?: boolean;
-  validate?: boolean;
 };
 
 export type TVLabsCapabilities =

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type TVLabsServiceOptions = {
   reconnectRetries?: number;
   attachRequestId?: boolean;
   continueOnError?: boolean;
+  validate?: boolean;
 };
 
 export type TVLabsCapabilities =

--- a/test-integration/cjs/attach-transform-request.test.mjs
+++ b/test-integration/cjs/attach-transform-request.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * Integration test: verifies that `transformRequest` installed by
+ * `TVLabsService.fromSession()` is actually invoked when WebdriverIO's
+ * `attach()` issues HTTP requests to the WebDriver server.
+ *
+ * This proves the end-to-end claim of `fromSession()`: that
+ * `lastRequestId()` and `x-request-id` header injection work on the
+ * attaching driver, not just on the driver that created the session.
+ */
+import { createServer } from 'node:http';
+import { createRequire } from 'module';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { attach } from 'webdriverio';
+
+const require = createRequire(import.meta.url);
+const { TVLabsService } = require('../../cjs/index.js');
+
+// ---------------------------------------------------------------------------
+// Minimal WebDriver stub server
+// ---------------------------------------------------------------------------
+
+let server;
+let serverPort;
+
+/** Captured headers from the most recent request to the stub. */
+let lastRequestHeaders = {};
+
+function startStubServer() {
+  return new Promise((resolve) => {
+    server = createServer((req, res) => {
+      lastRequestHeaders = req.headers;
+
+      // Respond with a minimal valid WebDriver JSON response for any endpoint
+      const body = JSON.stringify({ value: null });
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Length': body.length,
+      });
+      res.end(body);
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      serverPort = server.address().port;
+      resolve();
+    });
+  });
+}
+
+function stopStubServer() {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fromSession() + attach() — transformRequest end-to-end (CJS)', () => {
+  beforeAll(() => startStubServer());
+  afterAll(() => stopStubServer());
+
+  it('installs x-request-id on requests issued by the attached driver', async () => {
+    const appiumSessionId = 'test-appium-session-id';
+
+    const wdOpts = {
+      hostname: '127.0.0.1',
+      port: serverPort,
+      capabilities: {},
+      logLevel: 'silent',
+    };
+
+    // fromSession() mutates wdOpts.transformRequest in place
+    const service = TVLabsService.fromSession(
+      appiumSessionId,
+      { apiKey: 'test-key' },
+      wdOpts,
+    );
+
+    // attach() merges wdOpts and reads transformRequest from it
+    const driver = await attach({
+      sessionId: appiumSessionId,
+      ...wdOpts,
+      options: wdOpts,
+    });
+
+    // Trigger an HTTP request through the attached driver.
+    // executeScript hits POST /session/:id/execute/sync — a simple
+    // command that doesn't require a real browser to respond to.
+    await driver.execute('return 1').catch(() => {
+      // Stub returns `{ value: null }` which is valid; ignore any parse errors.
+    });
+
+    expect(lastRequestHeaders['x-request-id']).toBeDefined();
+    expect(typeof lastRequestHeaders['x-request-id']).toBe('string');
+    expect(lastRequestHeaders['x-request-id']).toHaveLength(36); // UUID v4
+
+    expect(service.lastRequestId()).toBe(lastRequestHeaders['x-request-id']);
+  });
+
+  it('lastRequestId() tracks the most recent request through the attached driver', async () => {
+    const appiumSessionId = 'test-appium-session-id-2';
+
+    const wdOpts = {
+      hostname: '127.0.0.1',
+      port: serverPort,
+      capabilities: {},
+      logLevel: 'silent',
+    };
+
+    const service = TVLabsService.fromSession(
+      appiumSessionId,
+      { apiKey: 'test-key' },
+      wdOpts,
+    );
+
+    const driver = await attach({
+      sessionId: appiumSessionId,
+      ...wdOpts,
+      options: wdOpts,
+    });
+
+    // First request
+    await driver.execute('return 1').catch(() => {});
+    const firstId = service.lastRequestId();
+
+    // Second request — id should change
+    await driver.execute('return 2').catch(() => {});
+    const secondId = service.lastRequestId();
+
+    expect(firstId).toBeDefined();
+    expect(secondId).toBeDefined();
+    expect(firstId).not.toBe(secondId);
+  });
+});

--- a/test-integration/cjs/require.test.mjs
+++ b/test-integration/cjs/require.test.mjs
@@ -99,7 +99,7 @@ describe('CJS Integration Tests', () => {
       expect(typeof wdOpts.transformRequest).toBe('function');
     });
 
-    it('should expose lastRequestId, requestMetadata, sessionMetadata, and appiumSessionId', () => {
+    it('should expose lastRequestId, requestMetadata, sessionMetadata, and rehydratedSessionId', () => {
       const capabilities = {};
       const wdOpts = { capabilities, logLevel: 'silent' };
 
@@ -112,7 +112,7 @@ describe('CJS Integration Tests', () => {
       expect(typeof service.lastRequestId).toBe('function');
       expect(typeof service.requestMetadata).toBe('function');
       expect(typeof service.sessionMetadata).toBe('function');
-      expect(service.appiumSessionId).toBe('fake-session-id');
+      expect(service.rehydratedSessionId).toBe('fake-session-id');
     });
 
     it('should inject Authorization header on wdOpts', () => {

--- a/test-integration/cjs/require.test.mjs
+++ b/test-integration/cjs/require.test.mjs
@@ -73,7 +73,7 @@ describe('CJS Integration Tests', () => {
       expect(service).toBeInstanceOf(TVLabsService);
     });
 
-    it('should set tvlabs:session_id on capabilities', () => {
+    it('should not mutate tvlabs:session_id on capabilities', () => {
       const capabilities = {};
       const wdOpts = { capabilities, logLevel: 'silent' };
 
@@ -83,7 +83,7 @@ describe('CJS Integration Tests', () => {
         wdOpts,
       );
 
-      expect(capabilities['tvlabs:session_id']).toBe('fake-session-id');
+      expect(capabilities['tvlabs:session_id']).toBeUndefined();
     });
 
     it('should install transformRequest on wdOpts', () => {
@@ -99,7 +99,7 @@ describe('CJS Integration Tests', () => {
       expect(typeof wdOpts.transformRequest).toBe('function');
     });
 
-    it('should expose lastRequestId, requestMetadata, sessionMetadata, and sessionId', () => {
+    it('should expose lastRequestId, requestMetadata, sessionMetadata, and appiumSessionId', () => {
       const capabilities = {};
       const wdOpts = { capabilities, logLevel: 'silent' };
 
@@ -112,7 +112,7 @@ describe('CJS Integration Tests', () => {
       expect(typeof service.lastRequestId).toBe('function');
       expect(typeof service.requestMetadata).toBe('function');
       expect(typeof service.sessionMetadata).toBe('function');
-      expect(service.sessionId).toBe('fake-session-id');
+      expect(service.appiumSessionId).toBe('fake-session-id');
     });
 
     it('should inject Authorization header on wdOpts', () => {

--- a/test-integration/cjs/require.test.mjs
+++ b/test-integration/cjs/require.test.mjs
@@ -55,6 +55,80 @@ describe('CJS Integration Tests', () => {
     expect(typeof service.requestMetadata).toBe('function');
   });
 
+  describe('fromSession', () => {
+    it('should have a static fromSession method', () => {
+      expect(typeof TVLabsService.fromSession).toBe('function');
+    });
+
+    it('should return a TVLabsService instance', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      const service = TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(service).toBeInstanceOf(TVLabsService);
+    });
+
+    it('should set tvlabs:session_id on capabilities', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(capabilities['tvlabs:session_id']).toBe('fake-session-id');
+    });
+
+    it('should install transformRequest on wdOpts', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(typeof wdOpts.transformRequest).toBe('function');
+    });
+
+    it('should expose lastRequestId, requestMetadata, sessionMetadata, and sessionId', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      const service = TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(typeof service.lastRequestId).toBe('function');
+      expect(typeof service.requestMetadata).toBe('function');
+      expect(typeof service.sessionMetadata).toBe('function');
+      expect(service.sessionId).toBe('fake-session-id');
+    });
+
+    it('should inject Authorization header on wdOpts', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(wdOpts.headers?.Authorization).toBe('Bearer test-key');
+    });
+  });
+
   describe('Authorization header injection', () => {
     it('should inject Authorization header when not present', () => {
       const config = {};

--- a/test-integration/esm/attach-transform-request.test.mjs
+++ b/test-integration/esm/attach-transform-request.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * Integration test: verifies that `transformRequest` installed by
+ * `TVLabsService.fromSession()` is actually invoked when WebdriverIO's
+ * `attach()` issues HTTP requests to the WebDriver server.
+ *
+ * This proves the end-to-end claim of `fromSession()`: that
+ * `lastRequestId()` and `x-request-id` header injection work on the
+ * attaching driver, not just on the driver that created the session.
+ */
+import { createServer } from 'node:http';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { attach } from 'webdriverio';
+import { TVLabsService } from '../../esm/index.js';
+
+// ---------------------------------------------------------------------------
+// Minimal WebDriver stub server
+// ---------------------------------------------------------------------------
+
+let server;
+let serverPort;
+
+/** Captured headers from the most recent request to the stub. */
+let lastRequestHeaders = {};
+
+function startStubServer() {
+  return new Promise((resolve) => {
+    server = createServer((req, res) => {
+      lastRequestHeaders = req.headers;
+
+      // Respond with a minimal valid WebDriver JSON response for any endpoint
+      const body = JSON.stringify({ value: null });
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      });
+      res.end(body);
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      serverPort = server.address().port;
+      resolve();
+    });
+  });
+}
+
+function stopStubServer() {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fromSession() + attach() — transformRequest end-to-end', () => {
+  beforeAll(() => startStubServer());
+  afterAll(() => stopStubServer());
+
+  it('installs x-request-id on requests issued by the attached driver', async () => {
+    const appiumSessionId = 'test-appium-session-id';
+
+    const wdOpts = {
+      hostname: '127.0.0.1',
+      port: serverPort,
+      capabilities: {},
+      logLevel: 'silent',
+    };
+
+    // fromSession() mutates wdOpts.transformRequest in place
+    const service = TVLabsService.fromSession(
+      appiumSessionId,
+      { apiKey: 'test-key' },
+      wdOpts,
+    );
+
+    // attach() merges wdOpts and reads transformRequest from it
+    const driver = await attach({
+      sessionId: appiumSessionId,
+      ...wdOpts,
+      options: wdOpts,
+    });
+
+    // Trigger an HTTP request through the attached driver.
+    // executeScript hits POST /session/:id/execute/sync — a simple
+    // command that doesn't require a real browser to respond to.
+    await driver.execute('return 1').catch(() => {
+      // Stub returns `{ value: null }` which is valid; ignore any parse errors.
+    });
+
+    expect(lastRequestHeaders['x-request-id']).toBeDefined();
+    expect(typeof lastRequestHeaders['x-request-id']).toBe('string');
+    expect(lastRequestHeaders['x-request-id']).toHaveLength(36); // UUID v4
+
+    expect(service.lastRequestId()).toBe(lastRequestHeaders['x-request-id']);
+  });
+
+  it('lastRequestId() tracks the most recent request through the attached driver', async () => {
+    const appiumSessionId = 'test-appium-session-id-2';
+
+    const wdOpts = {
+      hostname: '127.0.0.1',
+      port: serverPort,
+      capabilities: {},
+      logLevel: 'silent',
+    };
+
+    const service = TVLabsService.fromSession(
+      appiumSessionId,
+      { apiKey: 'test-key' },
+      wdOpts,
+    );
+
+    const driver = await attach({
+      sessionId: appiumSessionId,
+      ...wdOpts,
+      options: wdOpts,
+    });
+
+    // First request
+    await driver.execute('return 1').catch(() => {});
+    const firstId = service.lastRequestId();
+
+    // Second request — id should change
+    await driver.execute('return 2').catch(() => {});
+    const secondId = service.lastRequestId();
+
+    expect(firstId).toBeDefined();
+    expect(secondId).toBeDefined();
+    expect(firstId).not.toBe(secondId);
+  });
+});

--- a/test-integration/esm/attach-transform-request.test.mjs
+++ b/test-integration/esm/attach-transform-request.test.mjs
@@ -31,7 +31,7 @@ function startStubServer() {
       const body = JSON.stringify({ value: null });
       res.writeHead(200, {
         'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
+        'Content-Length': body.length,
       });
       res.end(body);
     });

--- a/test-integration/esm/import.test.mjs
+++ b/test-integration/esm/import.test.mjs
@@ -70,7 +70,7 @@ describe('ESM Integration Tests', () => {
       expect(service).toBeInstanceOf(TVLabsService);
     });
 
-    it('should set tvlabs:session_id on capabilities', () => {
+    it('should not mutate tvlabs:session_id on capabilities', () => {
       const capabilities = {};
       const wdOpts = { capabilities, logLevel: 'silent' };
 
@@ -80,7 +80,7 @@ describe('ESM Integration Tests', () => {
         wdOpts,
       );
 
-      expect(capabilities['tvlabs:session_id']).toBe('fake-session-id');
+      expect(capabilities['tvlabs:session_id']).toBeUndefined();
     });
 
     it('should install transformRequest on wdOpts', () => {
@@ -96,7 +96,7 @@ describe('ESM Integration Tests', () => {
       expect(typeof wdOpts.transformRequest).toBe('function');
     });
 
-    it('should expose lastRequestId, requestMetadata, sessionMetadata, and sessionId', () => {
+    it('should expose lastRequestId, requestMetadata, sessionMetadata, and appiumSessionId', () => {
       const capabilities = {};
       const wdOpts = { capabilities, logLevel: 'silent' };
 
@@ -109,7 +109,7 @@ describe('ESM Integration Tests', () => {
       expect(typeof service.lastRequestId).toBe('function');
       expect(typeof service.requestMetadata).toBe('function');
       expect(typeof service.sessionMetadata).toBe('function');
-      expect(service.sessionId).toBe('fake-session-id');
+      expect(service.appiumSessionId).toBe('fake-session-id');
     });
 
     it('should inject Authorization header on wdOpts', () => {

--- a/test-integration/esm/import.test.mjs
+++ b/test-integration/esm/import.test.mjs
@@ -96,7 +96,7 @@ describe('ESM Integration Tests', () => {
       expect(typeof wdOpts.transformRequest).toBe('function');
     });
 
-    it('should expose lastRequestId, requestMetadata, sessionMetadata, and appiumSessionId', () => {
+    it('should expose lastRequestId, requestMetadata, sessionMetadata, and rehydratedSessionId', () => {
       const capabilities = {};
       const wdOpts = { capabilities, logLevel: 'silent' };
 
@@ -109,7 +109,7 @@ describe('ESM Integration Tests', () => {
       expect(typeof service.lastRequestId).toBe('function');
       expect(typeof service.requestMetadata).toBe('function');
       expect(typeof service.sessionMetadata).toBe('function');
-      expect(service.appiumSessionId).toBe('fake-session-id');
+      expect(service.rehydratedSessionId).toBe('fake-session-id');
     });
 
     it('should inject Authorization header on wdOpts', () => {

--- a/test-integration/esm/import.test.mjs
+++ b/test-integration/esm/import.test.mjs
@@ -52,6 +52,80 @@ describe('ESM Integration Tests', () => {
     expect(typeof service.requestMetadata).toBe('function');
   });
 
+  describe('fromSession', () => {
+    it('should have a static fromSession method', () => {
+      expect(typeof TVLabsService.fromSession).toBe('function');
+    });
+
+    it('should return a TVLabsService instance', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      const service = TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(service).toBeInstanceOf(TVLabsService);
+    });
+
+    it('should set tvlabs:session_id on capabilities', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(capabilities['tvlabs:session_id']).toBe('fake-session-id');
+    });
+
+    it('should install transformRequest on wdOpts', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(typeof wdOpts.transformRequest).toBe('function');
+    });
+
+    it('should expose lastRequestId, requestMetadata, sessionMetadata, and sessionId', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      const service = TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(typeof service.lastRequestId).toBe('function');
+      expect(typeof service.requestMetadata).toBe('function');
+      expect(typeof service.sessionMetadata).toBe('function');
+      expect(service.sessionId).toBe('fake-session-id');
+    });
+
+    it('should inject Authorization header on wdOpts', () => {
+      const capabilities = {};
+      const wdOpts = { capabilities, logLevel: 'silent' };
+
+      TVLabsService.fromSession(
+        'fake-session-id',
+        { apiKey: 'test-key' },
+        wdOpts,
+      );
+
+      expect(wdOpts.headers?.Authorization).toBe('Bearer test-key');
+    });
+  });
+
   describe('Authorization header injection', () => {
     it('should inject Authorization header when not present', () => {
       const config = {};

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1007,7 +1007,9 @@ describe('TVLabsService', () => {
 
       const userHeader = 'x-my-header';
       const userHeaderValue = 'my-value';
-      const wdOpts: Options.WebdriverIO & { transformRequest?: (r: RequestInit) => RequestInit } = {
+      const wdOpts: Options.WebdriverIO & {
+        transformRequest?: (r: RequestInit) => RequestInit;
+      } = {
         capabilities,
         transformRequest: (requestOptions: RequestInit) => ({
           ...requestOptions,
@@ -1021,7 +1023,9 @@ describe('TVLabsService', () => {
       const service = TVLabsService.fromSession(sessionId, options, wdOpts);
 
       // Invoke the installed transformRequest hook
-      const result = wdOpts.transformRequest!({} as RequestInit) as { headers: Record<string, string> };
+      const result = wdOpts.transformRequest!({} as RequestInit) as {
+        headers: Record<string, string>;
+      };
 
       // The user's header must be present (user's transformRequest was called)
       expect(result.headers[userHeader]).toBe(userHeaderValue);
@@ -1032,7 +1036,6 @@ describe('TVLabsService', () => {
       // lastRequestId() must match what was injected
       expect(service.lastRequestId()).toBe(result.headers['x-request-id']);
     });
-
   });
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -767,22 +767,14 @@ describe('TVLabsService', () => {
 
   describe('disconnect', () => {
     it('is a no-op when no metadata channel was opened', async () => {
-      const service = new TVLabsService(
-        { apiKey: 'my-api-key' },
-        {},
-        {},
-      );
+      const service = new TVLabsService({ apiKey: 'my-api-key' }, {}, {});
 
       await expect(service.disconnect()).resolves.toBeUndefined();
       expect(fakeMetadataChannel.disconnect).not.toHaveBeenCalled();
     });
 
     it('closes the metadata channel after requestMetadata opened it', async () => {
-      const service = new TVLabsService(
-        { apiKey: 'my-api-key' },
-        {},
-        {},
-      );
+      const service = new TVLabsService({ apiKey: 'my-api-key' }, {}, {});
       const sessionId = randomUUID();
       const requestId = randomUUID();
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -765,6 +765,43 @@ describe('TVLabsService', () => {
     });
   });
 
+  describe('disconnect', () => {
+    it('is a no-op when no metadata channel was opened', async () => {
+      const service = new TVLabsService(
+        { apiKey: 'my-api-key' },
+        {},
+        {},
+      );
+
+      await expect(service.disconnect()).resolves.toBeUndefined();
+      expect(fakeMetadataChannel.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('closes the metadata channel after requestMetadata opened it', async () => {
+      const service = new TVLabsService(
+        { apiKey: 'my-api-key' },
+        {},
+        {},
+      );
+      const sessionId = randomUUID();
+      const requestId = randomUUID();
+
+      fakeMetadataChannel.getRequestMetadata.mockResolvedValue({
+        [requestId]: {},
+      });
+      fakeMetadataChannel.disconnect.mockResolvedValue(undefined);
+
+      await service.requestMetadata(sessionId, requestId);
+      await service.disconnect();
+
+      expect(fakeMetadataChannel.disconnect).toHaveBeenCalledTimes(1);
+
+      // Subsequent disconnect calls are no-ops
+      await service.disconnect();
+      expect(fakeMetadataChannel.disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('fromSession', () => {
     it('returns a TVLabsService instance synchronously', () => {
       const sessionId = randomUUID();
@@ -777,7 +814,7 @@ describe('TVLabsService', () => {
       expect(service).toBeInstanceOf(TVLabsService);
     });
 
-    it('sets tvlabs:session_id on the capabilities', () => {
+    it('does not mutate tvlabs:session_id on the capabilities', () => {
       const sessionId = randomUUID();
       const options = { apiKey: 'my-api-key' };
       const capabilities: TVLabsCapabilities = {};
@@ -785,7 +822,7 @@ describe('TVLabsService', () => {
 
       TVLabsService.fromSession(sessionId, options, wdOpts);
 
-      expect(capabilities['tvlabs:session_id']).toBe(sessionId);
+      expect(capabilities['tvlabs:session_id']).toBeUndefined();
     });
 
     it('installs transformRequest on wdOpts for request-id tracking', () => {
@@ -846,7 +883,7 @@ describe('TVLabsService', () => {
       expect(secondRequestId).not.toBe(firstRequestId);
     });
 
-    it('sessionId getter returns the bound session ID', () => {
+    it('appiumSessionId getter returns the bound Appium session ID', () => {
       const sessionId = randomUUID();
       const options = { apiKey: 'my-api-key' };
       const capabilities: TVLabsCapabilities = {};
@@ -854,17 +891,17 @@ describe('TVLabsService', () => {
 
       const service = TVLabsService.fromSession(sessionId, options, wdOpts);
 
-      expect(service.sessionId).toBe(sessionId);
+      expect(service.appiumSessionId).toBe(sessionId);
     });
 
-    it('sessionId getter returns undefined for classic instances', () => {
+    it('appiumSessionId getter returns undefined for classic instances', () => {
       const options = { apiKey: 'my-api-key' };
       const capabilities: TVLabsCapabilities = {};
       const config: Options.WebdriverIO = {};
 
       const service = new TVLabsService(options, capabilities, config);
 
-      expect(service.sessionId).toBeUndefined();
+      expect(service.appiumSessionId).toBeUndefined();
     });
 
     it('beforeSession throws on a rehydrated instance', async () => {
@@ -976,7 +1013,7 @@ describe('TVLabsService', () => {
 
         const service = await result;
         expect(service).toBeInstanceOf(TVLabsService);
-        expect(service.sessionId).toBe(sessionId);
+        expect(service.appiumSessionId).toBe(sessionId);
       });
 
       it('calls getSessionMetadata to validate the session', async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -988,64 +988,51 @@ describe('TVLabsService', () => {
       ).toThrow(SevereServiceError);
     });
 
-    describe('validate: true', () => {
-      it('returns a Promise that resolves to a TVLabsService', async () => {
-        const sessionId = randomUUID();
-        const options = { apiKey: 'my-api-key', validate: true as const };
-        const capabilities: TVLabsCapabilities = {};
-        const wdOpts: Options.WebdriverIO = { capabilities };
+    it('disconnect() is a no-op on a rehydrated instance with no open channel', async () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
 
-        vi.mocked(getSessionMetadata).mockResolvedValue({
-          id: sessionId,
-        });
+      const service = TVLabsService.fromSession(sessionId, options, wdOpts);
 
-        const result = TVLabsService.fromSession(sessionId, options, wdOpts);
-
-        expect(result).toBeInstanceOf(Promise);
-
-        const service = await result;
-        expect(service).toBeInstanceOf(TVLabsService);
-        expect(service.appiumSessionId).toBe(sessionId);
-      });
-
-      it('calls getSessionMetadata to validate the session', async () => {
-        const sessionId = randomUUID();
-        const options = { apiKey: 'my-api-key', validate: true as const };
-        const capabilities: TVLabsCapabilities = {};
-        const wdOpts: Options.WebdriverIO = { capabilities };
-
-        vi.mocked(getSessionMetadata).mockResolvedValue({});
-
-        await TVLabsService.fromSession(sessionId, options, wdOpts);
-
-        expect(getSessionMetadata).toHaveBeenCalledWith(
-          {
-            baseUrl: 'https://www.tvlabs.ai',
-            apiKey: 'my-api-key',
-            logLevel: 'info',
-          },
-          sessionId,
-        );
-      });
-
-      it('rejects with SevereServiceError when session is not found', async () => {
-        const sessionId = randomUUID();
-        const options = { apiKey: 'my-api-key', validate: true as const };
-        const capabilities: TVLabsCapabilities = {};
-        const wdOpts: Options.WebdriverIO = { capabilities };
-
-        vi.mocked(getSessionMetadata).mockRejectedValue(
-          new Error('API request failed: 404 Not Found'),
-        );
-
-        await expect(
-          TVLabsService.fromSession(sessionId, options, wdOpts),
-        ).rejects.toThrow(SevereServiceError);
-        await expect(
-          TVLabsService.fromSession(sessionId, options, wdOpts),
-        ).rejects.toThrow(`Cannot rehydrate: session ${sessionId}`);
-      });
+      await expect(service.disconnect()).resolves.toBeUndefined();
+      expect(fakeMetadataChannel.disconnect).not.toHaveBeenCalled();
     });
+
+    it('chains a user-provided transformRequest when attachRequestId is true', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+
+      const userHeader = 'x-my-header';
+      const userHeaderValue = 'my-value';
+      const wdOpts: Options.WebdriverIO & { transformRequest?: (r: RequestInit) => RequestInit } = {
+        capabilities,
+        transformRequest: (requestOptions: RequestInit) => ({
+          ...requestOptions,
+          headers: {
+            ...(requestOptions.headers as Record<string, string>),
+            [userHeader]: userHeaderValue,
+          },
+        }),
+      };
+
+      const service = TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      // Invoke the installed transformRequest hook
+      const result = wdOpts.transformRequest!({} as RequestInit) as { headers: Record<string, string> };
+
+      // The user's header must be present (user's transformRequest was called)
+      expect(result.headers[userHeader]).toBe(userHeaderValue);
+
+      // The x-request-id header must also be present (TVLabs hook ran)
+      expect(result.headers['x-request-id']).toBeDefined();
+
+      // lastRequestId() must match what was injected
+      expect(service.lastRequestId()).toBe(result.headers['x-request-id']);
+    });
+
   });
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -883,7 +883,7 @@ describe('TVLabsService', () => {
 
       const service = TVLabsService.fromSession(sessionId, options, wdOpts);
 
-      expect(service.appiumSessionId).toBe(sessionId);
+      expect(service.rehydratedSessionId).toBe(sessionId);
     });
 
     it('appiumSessionId getter returns undefined for classic instances', () => {
@@ -893,7 +893,7 @@ describe('TVLabsService', () => {
 
       const service = new TVLabsService(options, capabilities, config);
 
-      expect(service.appiumSessionId).toBeUndefined();
+      expect(service.rehydratedSessionId).toBeUndefined();
     });
 
     it('beforeSession throws on a rehydrated instance', async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -764,6 +764,260 @@ describe('TVLabsService', () => {
       );
     });
   });
+
+  describe('fromSession', () => {
+    it('returns a TVLabsService instance synchronously', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+
+      const service = TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      expect(service).toBeInstanceOf(TVLabsService);
+    });
+
+    it('sets tvlabs:session_id on the capabilities', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+
+      TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      expect(capabilities['tvlabs:session_id']).toBe(sessionId);
+    });
+
+    it('installs transformRequest on wdOpts for request-id tracking', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+
+      TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      expect(typeof wdOpts.transformRequest).toBe('function');
+    });
+
+    it('does not install transformRequest when attachRequestId is false', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key', attachRequestId: false };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+
+      TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      expect(wdOpts.transformRequest).toBeUndefined();
+    });
+
+    it('injects Authorization header on wdOpts', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+
+      TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      expect(wdOpts.headers?.Authorization).toBe('Bearer my-api-key');
+    });
+
+    it('lastRequestId returns the most recent ID after transformRequest fires', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+
+      const service = TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      expect(service.lastRequestId()).toBeUndefined();
+
+      // Simulate a request going through the transformRequest hook
+      const requestOptions: RequestInit = { headers: {} };
+      wdOpts.transformRequest!(requestOptions);
+
+      const firstRequestId = service.lastRequestId();
+      expect(firstRequestId).toBeDefined();
+      expect(typeof firstRequestId).toBe('string');
+
+      // Make another request - should return the newest ID
+      wdOpts.transformRequest!(requestOptions);
+      const secondRequestId = service.lastRequestId();
+      expect(secondRequestId).toBeDefined();
+      expect(secondRequestId).not.toBe(firstRequestId);
+    });
+
+    it('sessionId getter returns the bound session ID', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+
+      const service = TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      expect(service.sessionId).toBe(sessionId);
+    });
+
+    it('sessionId getter returns undefined for classic instances', () => {
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const config: Options.WebdriverIO = {};
+
+      const service = new TVLabsService(options, capabilities, config);
+
+      expect(service.sessionId).toBeUndefined();
+    });
+
+    it('beforeSession throws on a rehydrated instance', async () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+
+      const service = TVLabsService.fromSession(sessionId, options, wdOpts);
+
+      await expect(
+        service.beforeSession(wdOpts, capabilities, [], ''),
+      ).rejects.toThrow(SevereServiceError);
+      await expect(
+        service.beforeSession(wdOpts, capabilities, [], ''),
+      ).rejects.toThrow('beforeSession() is not valid on a rehydrated service');
+    });
+
+    it('requestMetadata works without beforeSession', async () => {
+      const sessionId = randomUUID();
+      const requestId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+      const mockMetadata = {
+        path: '/session/123/element',
+        method: 'POST',
+        status: 200,
+      };
+
+      fakeMetadataChannel.getRequestMetadata.mockResolvedValue({
+        [requestId]: mockMetadata,
+      });
+
+      const service = TVLabsService.fromSession(sessionId, options, wdOpts);
+      const result = await service.requestMetadata(sessionId, requestId);
+
+      expect(fakeMetadataChannel.connect).toHaveBeenCalled();
+      expect(fakeMetadataChannel.getRequestMetadata).toHaveBeenCalledWith(
+        sessionId,
+        [requestId],
+      );
+      expect(result).toEqual(mockMetadata);
+    });
+
+    it('sessionMetadata works without beforeSession', async () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const capabilities: TVLabsCapabilities = {};
+      const wdOpts: Options.WebdriverIO = { capabilities };
+      const mockResponse = {
+        id: sessionId,
+        recording_started_at: '2026-04-21T12:00:00Z',
+      };
+
+      vi.mocked(getSessionMetadata).mockResolvedValue(mockResponse);
+
+      const service = TVLabsService.fromSession(sessionId, options, wdOpts);
+      const result = await service.sessionMetadata(sessionId);
+
+      expect(result).toEqual(mockResponse);
+      expect(getSessionMetadata).toHaveBeenCalledWith(
+        {
+          baseUrl: 'https://www.tvlabs.ai',
+          apiKey: 'my-api-key',
+          logLevel: 'info',
+        },
+        sessionId,
+      );
+    });
+
+    it('throws when capabilities is missing', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const wdOpts: Options.WebdriverIO = {};
+
+      expect(() =>
+        TVLabsService.fromSession(sessionId, options, wdOpts),
+      ).toThrow(SevereServiceError);
+      expect(() =>
+        TVLabsService.fromSession(sessionId, options, wdOpts),
+      ).toThrow('wdOpts.capabilities must be a capabilities object');
+    });
+
+    it('throws when capabilities is an array (multi-remote)', () => {
+      const sessionId = randomUUID();
+      const options = { apiKey: 'my-api-key' };
+      const wdOpts = { capabilities: [] } as unknown as Options.WebdriverIO;
+
+      expect(() =>
+        TVLabsService.fromSession(sessionId, options, wdOpts),
+      ).toThrow(SevereServiceError);
+    });
+
+    describe('validate: true', () => {
+      it('returns a Promise that resolves to a TVLabsService', async () => {
+        const sessionId = randomUUID();
+        const options = { apiKey: 'my-api-key', validate: true as const };
+        const capabilities: TVLabsCapabilities = {};
+        const wdOpts: Options.WebdriverIO = { capabilities };
+
+        vi.mocked(getSessionMetadata).mockResolvedValue({
+          id: sessionId,
+        });
+
+        const result = TVLabsService.fromSession(sessionId, options, wdOpts);
+
+        expect(result).toBeInstanceOf(Promise);
+
+        const service = await result;
+        expect(service).toBeInstanceOf(TVLabsService);
+        expect(service.sessionId).toBe(sessionId);
+      });
+
+      it('calls getSessionMetadata to validate the session', async () => {
+        const sessionId = randomUUID();
+        const options = { apiKey: 'my-api-key', validate: true as const };
+        const capabilities: TVLabsCapabilities = {};
+        const wdOpts: Options.WebdriverIO = { capabilities };
+
+        vi.mocked(getSessionMetadata).mockResolvedValue({});
+
+        await TVLabsService.fromSession(sessionId, options, wdOpts);
+
+        expect(getSessionMetadata).toHaveBeenCalledWith(
+          {
+            baseUrl: 'https://www.tvlabs.ai',
+            apiKey: 'my-api-key',
+            logLevel: 'info',
+          },
+          sessionId,
+        );
+      });
+
+      it('rejects with SevereServiceError when session is not found', async () => {
+        const sessionId = randomUUID();
+        const options = { apiKey: 'my-api-key', validate: true as const };
+        const capabilities: TVLabsCapabilities = {};
+        const wdOpts: Options.WebdriverIO = { capabilities };
+
+        vi.mocked(getSessionMetadata).mockRejectedValue(
+          new Error('API request failed: 404 Not Found'),
+        );
+
+        await expect(
+          TVLabsService.fromSession(sessionId, options, wdOpts),
+        ).rejects.toThrow(SevereServiceError);
+        await expect(
+          TVLabsService.fromSession(sessionId, options, wdOpts),
+        ).rejects.toThrow(`Cannot rehydrate: session ${sessionId}`);
+      });
+    });
+  });
 });
 
 const fakeSessionChannel = {


### PR DESCRIPTION
## Summary

- Adds `TVLabsService.fromSession(appiumSessionId, options, wdOpts)` static factory that binds a service instance to an existing Appium session — the counterpart to WebdriverIO's `attach()`.
- Mutates `wdOpts` to inject the auth header and install the `x-request-id` tracking hook before `attach()` is called, so `lastRequestId()` works on the attaching driver.
- Returns synchronously. To verify the session exists before using it, call `await service.sessionMetadata(appiumSessionId)` immediately after construction.
- Guards `beforeSession()` on instances created via `fromSession()` with a `SevereServiceError`, to prevent accidentally recreating the session.
- Adds an `appiumSessionId` getter exposing the bound session ID.
- Adds `disconnect()` so callers can close the metadata channel WebSocket and let the process exit.

## Motivation

WebdriverIO supports [`attach({ sessionId })`](https://webdriver.io/docs/api/modules#attachoptions) for reusing an existing WebDriver session — useful any time session creation and session usage are split across processes (parallel test workers, a fixture process that hands sessions to test files, an orchestrator that allocates sessions for child runners, a debug REPL reattaching to a live session).

Before this change, `@tvlabs/wdio-service` had no `attach()` story. The telemetry surface (`lastRequestId()`, `requestMetadata()`, `sessionMetadata()`) only worked on the same instance that called `beforeSession()`, so the attaching driver lost request tracking and metadata access.

`fromSession()` fills that gap. The Appium session ID — the value of `driver.sessionId` after the original `remote()` call — is the portable handle: pass it to the attaching process alongside the API key, call `fromSession()` before `attach()`, and the telemetry methods work as normal.

## Usage

```js
// Where the session is created
const service = new TVLabsService(
  { apiKey: process.env.TVLABS_API_KEY },
  capabilities,
  wdOpts
);
await service.beforeSession(wdOpts, capabilities, [], '');
const driver = await remote(wdOpts);

// Hand driver.sessionId off to the attaching process via env var,
// fixture, queue message, file — whatever your test setup uses.
const appiumSessionId = driver.sessionId;
```

```js
// Where the session is attached to later
const service = TVLabsService.fromSession(
  appiumSessionId,
  { apiKey: process.env.TVLABS_API_KEY },
  wdOpts  // same reference passed to attach()
);

const driver = await attach({
  sessionId: appiumSessionId,
  ...wdOpts,
  options: wdOpts,
});

const requestId = service.lastRequestId();
const metadata  = await service.requestMetadata(appiumSessionId, requestId);
```

## Changes

- `src/service.ts` — `fromSession()` factory, `appiumSessionId` getter, `beforeSession()` guard, `disconnect()`
- `src/types.ts` — no net change (validate option added then removed during review)
- `test/service.test.ts` — new unit tests for the factory, `transformRequest` chaining, and `disconnect()`
- `test-integration/esm/attach-transform-request.test.mjs` — end-to-end test proving `transformRequest` fires through `attach()` against a real HTTP stub
- `test-integration/` — smoke tests per module format (ESM + CJS)
- `README.md` — restructured: `fromSession()` docs, `disconnect()` docs, "Attaching to an Existing Session" usage section

## Test results

```
Unit:        8 files, 110 tests
Integration: 3 files, 34 tests (18 ESM + 16 CJS)
```

All 88 existing tests continue to pass (backward compatibility). 34 new tests added.