### PR TITLE
chore(logger): drop stale TODO, add WDIO_LOG_LEVEL fallback

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,5 @@
 import type { LogLevel } from './types.js';
 
-// TODO: Replace this with @wdio/logger
-// It is currently not compatible with CJS
-
 const LOG_LEVELS: Record<LogLevel, number> = {
   error: 0,
   warn: 1,
@@ -12,11 +9,20 @@ const LOG_LEVELS: Record<LogLevel, number> = {
   silent: 5,
 };
 
+function envLogLevel(): LogLevel | undefined {
+  const value = process.env.WDIO_LOG_LEVEL;
+  return value && value in LOG_LEVELS ? (value as LogLevel) : undefined;
+}
+
 export class Logger {
+  private logLevel: LogLevel;
+
   constructor(
     private name: string,
-    private logLevel: LogLevel = 'info',
-  ) {}
+    logLevel?: LogLevel,
+  ) {
+    this.logLevel = logLevel ?? envLogLevel() ?? 'info';
+  }
 
   private shouldLog(level: LogLevel): boolean {
     if (this.logLevel === 'silent') {

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -177,4 +177,47 @@ describe('Logger', () => {
       expect(consoleSpy.trace).not.toHaveBeenCalled();
     });
   });
+
+  describe('WDIO_LOG_LEVEL env fallback', () => {
+    const originalEnv = process.env.WDIO_LOG_LEVEL;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.WDIO_LOG_LEVEL;
+      } else {
+        process.env.WDIO_LOG_LEVEL = originalEnv;
+      }
+    });
+
+    it('uses WDIO_LOG_LEVEL when no level is passed', () => {
+      process.env.WDIO_LOG_LEVEL = 'debug';
+      const logger = new Logger('test');
+
+      logger.debug('debug message');
+
+      expect(consoleSpy.log).toHaveBeenCalledTimes(1);
+    });
+
+    it('explicit level wins over WDIO_LOG_LEVEL', () => {
+      process.env.WDIO_LOG_LEVEL = 'debug';
+      const logger = new Logger('test', 'error');
+
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.error('error message');
+
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+      expect(consoleSpy.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to info when WDIO_LOG_LEVEL is invalid', () => {
+      process.env.WDIO_LOG_LEVEL = 'bogus';
+      const logger = new Logger('test');
+
+      logger.debug('debug message');
+      logger.info('info message');
+
+      expect(consoleSpy.log).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -38,7 +38,7 @@ vi.mock('../src/api/sessions', () => {
   };
 });
 
-vi.stubGlobal('process', { exit: vi.fn() });
+vi.stubGlobal('process', { exit: vi.fn(), env: {} });
 
 describe('TVLabsService', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- Removes the stale `// TODO: Replace this with @wdio/logger` comment in `src/logger.ts` (issue #22). The original CJS-incompatibility rationale no longer holds — Rollup already gives us dual ESM/CJS, and `@wdio/logger@9.18+` now publishes both formats.
- Adopting `@wdio/logger` anyway would add five transitive runtime deps (`chalk`, `loglevel`, `loglevel-plugin-prefix`, `safe-regex2`, `strip-ansi`) for features the service does not use. We are keeping the in-house `Logger`.
- Adds a `WDIO_LOG_LEVEL` env-var fallback in the `Logger` constructor so users can bump verbosity without editing `wdio.conf.ts`. Precedence: explicit arg > env > `'info'`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` — 96/96 pass (3 new tests cover env applied, explicit-wins-over-env, invalid-env-falls-back-to-info)
- [x] `npm run build` produces both `esm/` and `cjs/`
- [x] `npm run test:integration:esm` and `npm run test:integration:cjs` both pass
- [ ] Manual: run a wdio test with `WDIO_LOG_LEVEL=debug` and confirm service debug lines appear

Closes #22